### PR TITLE
fix ./gradlew os:server:server-development:build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
+import org.gradle.jvm.tasks.Jar
 
 plugins {
   id("wasmo-build").apply(false)
@@ -18,6 +19,12 @@ plugins {
 }
 
 allprojects {
+  // Ensure jar file name derives from the whole gradle task path so that the various :real tasks don't conflict.
+  val uniqueArchiveBaseName = path.removePrefix(":").replace(':', '-')
+  tasks.withType<Jar>().configureEach {
+    archiveBaseName.set(uniqueArchiveBaseName)
+  }
+
   plugins.withType<KotlinMultiplatformPluginWrapper> {
     extensions.configure<KotlinMultiplatformExtension> {
       compilerOptions {


### PR DESCRIPTION
distTar was pulling in two artifacts with the same archive path, `server-development/lib/real-jvm.jar`

This was because several modules end with `:real`, and their JVM jars are probably all being published with the same archive base name `real`.

This broke the build:

```
$ ./gradlew os:server:server-development:build
Execution failed for task ':os:server:server-development:distTar'.
> Entry server-development/lib/real-jvm.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/9.2.1/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```

I'm fixing this by setting an archiveBaseName for each <Jar> task, based on the respective task's path. The gradle target path seems to always start with ":", so without the `removePrefix()` we'd get names like `-os-server-server-development.jar`.

Result:

```
$  tar -tf os/server/server-development/build/distributions/server-development.tar | grep '^server-development/lib/.*\.jar$'
server-development/lib/os-server-server-development.jar
server-development/lib/os-server-ktor-jvm.jar
server-development/lib/apps-journal-wasmo-app-jvm.jar
server-development/lib/apps-samples-jvm.jar
server-development/lib/os-server-accounts-real-jvm.jar
server-development/lib/os-server-computers-real-jvm.jar
server-development/lib/os-server-website-real-jvm.jar
server-development/lib/os-server-calls-real-jvm.jar
server-development/lib/os-server-installedapps-real-jvm.jar
[...]
```