### PR TITLE
Automatically initialize/migrate DB schema on start.

### DIFF
--- a/docs/platform/plans/db_schema_migrations.md
+++ b/docs/platform/plans/db_schema_migrations.md
@@ -29,7 +29,7 @@ ON CONFLICT (id) DO NOTHING;
 ```
    2. Then,
      - If `version` from the table `< CURRENT_SCHEMA_VERSION`, run `migrate(oldVersion=version, newVersion=CURRENT_SCHEMA_VERSION)`.
-     - If `version > CURRENT_SCHEMA_VERSION`, wipe the database (drop, recreate DatabaseSchemaVersion table at version 0, run migrations).
+     - If `version > CURRENT_SCHEMA_VERSION`, throw `SqlException`.
      - Else, do nothing.
  - `WasmoService.startWasmoService()` calls `ensureSchemaVersion(CURRENT_SCHEMA_VERSION)` right after
    obtaining `wasmoDb` ([code](https://github.com/wasmcomputercompany/wasmo/blob/8c0da2da837a94fe5f7c66640eb51ca2f8dc5140/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt#L60)).

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/Migrate.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/Migrate.kt
@@ -1,17 +1,24 @@
 package com.wasmo.db
 
+import com.wasmo.db.schemaversion.getOrCreateSchemaVersion
+import com.wasmo.db.schemaversion.setSchemaVersion
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
 import wasmo.sql.SqlConnection
+import wasmo.sql.SqlException
 
 /**
  * Applies migrations from resources.
  *
+ * This function is agnostic of schema version metadata. It's the caller's
+ * responsibility to check and update the schema version record before/after
+ * the call.
+ *
  * Migration files must be named like `v1__Account.sql`. They're applied in number order.
  */
 context(sqlConnection: SqlConnection)
-suspend fun migrate(
+private suspend fun migrate(
   oldVersion: Long = 0L,
   newVersion: Long = CURRENT_SCHEMA_VERSION,
 ) {
@@ -30,6 +37,17 @@ suspend fun migrate(
       readUtf8()
     }
     sqlConnection.execute(migrationSql)
+  }
+}
+
+context(sqlConnection: SqlConnection)
+suspend fun ensureSchemaVersion(targetVersion: Long = CURRENT_SCHEMA_VERSION) {
+  val oldVersion = getOrCreateSchemaVersion().version
+  if (oldVersion > targetVersion) {
+    throw SqlException("DB schema downgrade not supported: $oldVersion -> $targetVersion")
+  } else if (oldVersion < targetVersion) {
+    migrate(oldVersion, targetVersion)
+    setSchemaVersion(version = targetVersion)
   }
 }
 

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/WasmoSql.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/WasmoSql.kt
@@ -16,6 +16,7 @@ import com.wasmo.identifiers.InviteId
 import com.wasmo.identifiers.LinkedEmailAddressId
 import com.wasmo.identifiers.PasskeyId
 import com.wasmo.identifiers.PermitId
+import com.wasmo.identifiers.SchemaVersionId
 import com.wasmo.identifiers.StripeCustomerId
 import com.wasmo.identifiers.UserId
 import com.wasmo.identifiers.WasmoFileAddress
@@ -66,6 +67,7 @@ fun SqlRow.getInviteId(index: Int) = InviteId(getS64(index)!!)
 fun SqlRow.getLinkedEmailAddressId(index: Int) = LinkedEmailAddressId(getS64(index)!!)
 fun SqlRow.getPasskeyId(index: Int) = PasskeyId(getS64(index)!!)
 fun SqlRow.getPermitId(index: Int) = PermitId(getS64(index)!!)
+fun SqlRow.getSchemaVersionId(index: Int) = SchemaVersionId(getS64(index)!!)
 fun SqlRow.getStripeCustomerId(index: Int) = StripeCustomerId(getS64(index)!!)
 fun SqlRow.getUserId(index: Int) = UserId(getS64(index)!!)
 fun SqlRow.getWasmoFileAddress(index: Int) = getString(index)!!.toWasmoFileAddress()

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/schemaversion/DbSchemaVersion.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/schemaversion/DbSchemaVersion.kt
@@ -1,0 +1,9 @@
+package com.wasmo.db.schemaversion
+
+import com.wasmo.identifiers.SchemaVersionId
+
+data class DbSchemaVersion(
+  val id: SchemaVersionId,
+  val version: Long,
+)
+

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/schemaversion/SchemaVersionQueries.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/schemaversion/SchemaVersionQueries.kt
@@ -1,0 +1,71 @@
+package com.wasmo.db.schemaversion
+
+import com.wasmo.db.getSchemaVersionId
+import wasmo.sql.SqlConnection
+import wasmo.sql.SqlRow
+import wasmox.sql.single
+
+// id (primary key) of the one and only row that's ever in the table
+private const val DB_SCHEMA_VERSION_ID = 1
+
+context(connection: SqlConnection)
+suspend fun getOrCreateSchemaVersion(): DbSchemaVersion {
+  ensureSchemaVersionStored()
+  return getSchemaVersion()
+}
+
+context(connection: SqlConnection)
+suspend fun getSchemaVersion(): DbSchemaVersion {
+  val rowIterator = connection.executeQuery(
+    "SELECT id, version FROM DatabaseSchemaVersion WHERE id=$1"
+  ) {
+    bindS32(0, DB_SCHEMA_VERSION_ID)
+  }
+  return rowIterator.single() {
+    getSchemaVersion()
+  }
+}
+
+context(connection: SqlConnection)
+suspend fun setSchemaVersion(version: Long) {
+  val rowIterator = connection.execute(
+    "UPDATE DatabaseSchemaVersion SET version=$1 WHERE id=$2"
+  ) {
+    bindS64(0, version)
+    bindS32(1, DB_SCHEMA_VERSION_ID)
+  }
+}
+
+context(connection: SqlConnection)
+private suspend fun ensureSchemaVersionStored() {
+  // execute() each statement individually for finer-grained errors and to not
+  // depend on driver support for multiple statements per execute().
+  connection.execute(
+    // Use String interpolation because $1 arg placeholders aren't supported for CREATE TABLE.
+    // https://www.postgresql.org/docs/current/sql-prepare.html
+    """
+    CREATE TABLE IF NOT EXISTS DatabaseSchemaVersion (
+      id INTEGER NOT NULL PRIMARY KEY DEFAULT $DB_SCHEMA_VERSION_ID,
+      version INTEGER NOT NULL
+    )
+    """
+  )
+  connection.execute("ALTER TABLE DatabaseSchemaVersion DROP CONSTRAINT IF EXISTS only_one_row")
+  // Use String interpolation because $1 arg placeholders aren't supported for ALTER TABLE.
+  // https://www.postgresql.org/docs/current/sql-prepare.html
+  connection.execute("ALTER TABLE DatabaseSchemaVersion ADD CONSTRAINT only_one_row CHECK (id = $DB_SCHEMA_VERSION_ID)")
+  connection.execute(
+    """
+    INSERT INTO DatabaseSchemaVersion (id, version)
+      VALUES ($1, 0)
+      ON CONFLICT (id) DO NOTHING;
+    """
+  ) {
+    bindS32(0, DB_SCHEMA_VERSION_ID)
+  }
+}
+
+private fun SqlRow.getSchemaVersion(): DbSchemaVersion = DbSchemaVersion(
+  id = getSchemaVersionId(0),
+  version = getS64(1)!!,
+)

--- a/os/server/identifiers/src/jvmMain/kotlin/com/wasmo/identifiers/DbIdentifiers.kt
+++ b/os/server/identifiers/src/jvmMain/kotlin/com/wasmo/identifiers/DbIdentifiers.kt
@@ -56,6 +56,10 @@ value class PermitId(val id: Long)
 
 @Serializable
 @JvmInline
+value class SchemaVersionId(val id: Long)
+
+@Serializable
+@JvmInline
 value class StripeCustomerId(val id: Long)
 
 @Serializable

--- a/os/server/ktor/build.gradle.kts
+++ b/os/server/ktor/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
         implementation(projects.platform.packaging)
         implementation(projects.support.issues)
         implementation(projects.support.tokens)
+        implementation(projects.wasmox.wasmoxSql)
       }
     }
   }

--- a/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
+++ b/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
@@ -4,6 +4,7 @@ package com.wasmo.ktor
 
 import com.wasmo.accounts.SessionCookieSpec
 import com.wasmo.common.catalog.Catalog
+import com.wasmo.db.ensureSchemaVersion
 import com.wasmo.identifiers.Deployment
 import com.wasmo.identifiers.OsScope
 import com.wasmo.objectstore.ObjectStoreAddress
@@ -18,7 +19,10 @@ import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.netty.EngineMain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okio.ByteString
+import wasmox.sql.transaction
 
 @Inject
 @SingleIn(OsScope::class)
@@ -58,6 +62,12 @@ suspend fun startWasmoService(
       .asSqlDatabase(),
   )
   val wasmoDb = osPostgresqlClient.asSqlDatabase()
+
+  withContext(Dispatchers.IO) {
+    wasmoDb.transaction {
+      ensureSchemaVersion()
+    }
+  }
 
   val wasmoServiceGraphFactory = createGraphFactory<WasmoServiceGraph.Factory>()
   val serviceGraph = wasmoServiceGraphFactory.create(

--- a/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTester.kt
+++ b/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTester.kt
@@ -3,7 +3,7 @@ package com.wasmo.testing.service
 import app.cash.burst.coroutines.CoroutineTestFunction
 import app.cash.burst.coroutines.CoroutineTestInterceptor
 import com.wasmo.accounts.ClientAuthenticator
-import com.wasmo.db.migrate
+import com.wasmo.db.ensureSchemaVersion
 import com.wasmo.jobs.OsJobQueue
 import com.wasmo.passkeys.RealAuthenticatorDatabase
 import com.wasmo.permits.PermitService
@@ -126,7 +126,7 @@ class ServiceTester : CoroutineTestInterceptor {
       )
 
       wasmoDb.withConnection {
-        migrate()
+        ensureSchemaVersion()
       }
 
       intercept(


### PR DESCRIPTION
This commit implements the proposal from docs/platform/plans/db_schema_migrations.md

Notes:

 - `migrate()` is unchanged but now private, since it's unaware of DbSchemaVersion metadata.
 - Version downgrade throws rather than wiping data:
   - Ensures user consent for data loss.
   - Simpler: DROP DATABASE works from the command line, but not inside a SqlConnection.
 - This PR has two commits; the second adds the transaction. This is  because it introduces a new dependency on wasmoxSql.

Future / open questions:

 - Unit test; does our infra support in-memory DB for testing? ServiceTester looks heavyweight.