### PR TITLE
WasmoService.start(): Don't block the current thread.

### DIFF
--- a/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
+++ b/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
@@ -32,7 +32,8 @@ class WasmoService(
 ) {
   fun start() {
     actionRouter.createRoutes()
-    server.start(true)
+    // don't permanently block the calling thread
+    server.start(wait = false)
   }
 
   data class Config(
@@ -63,6 +64,12 @@ suspend fun startWasmoService(
   )
   val wasmoDb = osPostgresqlClient.asSqlDatabase()
 
+  // On plain JVM outside of UI toolkits, the main thread appears to not have
+  // a coroutine dispatcher that execution can return to.
+  //
+  // withContext(Dispatchers.IO) ensures that remaining execution can at least
+  // return to one of plentiful I/O threads; else, it'd continue on whatever
+  // thread it had migrated to (empirically, the Vert.x eventloop thread).
   withContext(Dispatchers.IO) {
     wasmoDb.transaction {
       ensureSchemaVersion()


### PR DESCRIPTION
Initially, WasmoService.startWasmoService() runs on the JVM main thread.

During the DB schema migration, suspend fun execution apparently
transfers to a Vert.x eventloop thread (vert.x-eventloop-thread-0).

It sounds like Dispatchers.MAIN is available on the JVM main thread only
in the case of UI toolkits - because plain JVM is not mentioned in [1].

[1] https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html

These UI toolkits have a looper on their main thread, and I suspect that
that is why coroutine execution can return there, but that a plain JVM
`main` thread does not.

By keeping `withContext(Dispatchers.IO)`, we ensure that execution can
return to one of a large (but finite) number of I/O threadpool threads,
rather than staying on the vert.x eventloop thread.

By using `server.start(wait=false)`, we ensure that this execution will
continue only for a short while, rather than blocking the I/O thread
permanently.

I've manually confirmed that on a shell running:

`./gradlew os:distributions:homelab:run`

the server still keeps running but exits on Ctrl+C.