### PR TITLE
Use runBlocking() instead of suspend fun main

### DIFF
--- a/os/distributions/homelab/build.gradle.kts
+++ b/os/distributions/homelab/build.gradle.kts
@@ -14,6 +14,7 @@ application {
 
 dependencies {
   add("jsResources", projects.os.client.appHomelab)
+  implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okhttp)
   implementation(libs.okio)
   implementation(projects.apps.journal.wasmoApp)

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
@@ -14,11 +14,12 @@ import com.wasmo.sendemail.postmark.PostmarkCredentials
 import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
 import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.stripe.StripeCredentials
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okio.ByteString.Companion.encodeUtf8
 import okio.Path.Companion.toPath
 
-suspend fun main(args: Array<String>) {
+fun main(args: Array<String>): Unit = runBlocking {
   val stripePublishableKey = System.getenv("STRIPE_PUBLISHABLE_KEY")
     ?: error("required env STRIPE_PUBLISHABLE_KEY not set")
   val stripeSecretKey = System.getenv("STRIPE_SECRET_KEY")

--- a/os/distributions/hosted/build.gradle.kts
+++ b/os/distributions/hosted/build.gradle.kts
@@ -14,6 +14,7 @@ application {
 
 dependencies {
   add("jsResources", projects.os.client.appHosted)
+  implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okhttp)
   implementation(libs.okio)
   implementation(projects.os.api)

--- a/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedWasmoOs.kt
+++ b/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedWasmoOs.kt
@@ -14,10 +14,11 @@ import com.wasmo.sendemail.postmark.PostmarkCredentials
 import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
 import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.stripe.StripeCredentials
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okio.ByteString.Companion.decodeHex
 
-suspend fun main(args: Array<String>) {
+fun main(args: Array<String>): Unit = runBlocking {
   val cookieSecret = System.getenv("COOKIE_SECRET")
     ?: error("required env COOKIE_SECRET not set")
 

--- a/os/distributions/sandbox/build.gradle.kts
+++ b/os/distributions/sandbox/build.gradle.kts
@@ -14,6 +14,7 @@ application {
 
 dependencies {
   add("jsResources", projects.os.client.appSandbox)
+  implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okhttp)
   implementation(libs.okio)
   implementation(projects.os.api)

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
@@ -14,10 +14,11 @@ import com.wasmo.sendemail.postmark.PostmarkCredentials
 import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
 import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.stripe.StripeCredentials
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okio.ByteString.Companion.decodeHex
 
-suspend fun main(args: Array<String>) {
+fun main(args: Array<String>): Unit = runBlocking {
   val cookieSecret = System.getenv("COOKIE_SECRET")
     ?: error("required env COOKIE_SECRET not set")
 

--- a/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
+++ b/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt
@@ -19,8 +19,6 @@ import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.netty.EngineMain
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import okio.ByteString
 import wasmox.sql.transaction
 
@@ -64,16 +62,8 @@ suspend fun startWasmoService(
   )
   val wasmoDb = osPostgresqlClient.asSqlDatabase()
 
-  // On plain JVM outside of UI toolkits, the main thread appears to not have
-  // a coroutine dispatcher that execution can return to.
-  //
-  // withContext(Dispatchers.IO) ensures that remaining execution can at least
-  // return to one of plentiful I/O threads; else, it'd continue on whatever
-  // thread it had migrated to (empirically, the Vert.x eventloop thread).
-  withContext(Dispatchers.IO) {
-    wasmoDb.transaction {
-      ensureSchemaVersion()
-    }
+  wasmoDb.transaction {
+    ensureSchemaVersion()
   }
 
   val wasmoServiceGraphFactory = createGraphFactory<WasmoServiceGraph.Factory>()

--- a/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/Postgresql.kt
+++ b/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/Postgresql.kt
@@ -1,17 +1,33 @@
 package com.wasmo.sql
 
+import io.vertx.core.Completable
 import io.vertx.core.Future
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.RowSet
 import io.vertx.sqlclient.SqlClient
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.future.asDeferred
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 suspend inline fun SqlClient.execute(
   sql: String,
 ): RowSet<Row> {
-  return query(sql).execute().asDeferred().await()
+  return query(sql).execute().awaitSuspending()
 }
 
-fun <T> Future<T>.asDeferred(): Deferred<T> =
-  toCompletionStage().asDeferred()
+/** @param onCancellation to release the result value if it holds any resources. */
+suspend fun <T> Future<T>.awaitSuspending(
+  onCancellation: ((cause: Throwable, value: T, context: CoroutineContext) -> Unit)? = null,
+): T {
+  val future = this
+  return suspendCancellableCoroutine { continuation ->
+    future.onComplete(
+      Completable<T> { result, failure ->
+        when {
+          failure == null -> continuation.resume(result, onCancellation)
+          else -> continuation.resumeWithException(failure)
+        }
+      },
+    )
+  }
+}

--- a/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/PostgresqlClient.kt
+++ b/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/PostgresqlClient.kt
@@ -21,12 +21,14 @@ class PostgresqlClient(
     try {
       return block(connection)
     } finally {
-      connection.close().asDeferred().await()
+      connection.close().awaitSuspending()
     }
   }
 
   suspend fun connect(): SqlClient =
-    pool.connection.asDeferred().await()
+    pool.connection.awaitSuspending(
+      onCancellation = { _, value, _ -> value.close() },
+    )
 
   override fun close() {
     pool.close()

--- a/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/RealSqlDatabase.kt
+++ b/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/RealSqlDatabase.kt
@@ -85,7 +85,7 @@ internal class RealSqlConnection(
         else -> sqlClient.query(sql).execute()
       }
 
-      return future.asDeferred().await()
+      return future.awaitSuspending()
     } catch (e: PgException) {
       throw e.toSqlException()
     }


### PR DESCRIPTION
I think 'suspend fun main' is a trap, it doesn't have a good enough dispatcher to resume a continuation.

I suspect the underlying cause of this deficiency is that 'suspend' is language feature, but 'runBlocking' is in the coroutines library.

Either way, this fixes the app launch to use the main dispatcher before and after the database migration is performed.