### PR TITLE
automatically install absurd in Wasmo DB as part of migrations

### DIFF
--- a/docs/local_development/absurd.md
+++ b/docs/local_development/absurd.md
@@ -5,7 +5,10 @@ Absurd powers some workflow code in Wasmo OS.
 
 ℹ️ Prerequisite: [PostgreSQL](postgresql.md).
 
-Only install it if you’d like to use their tooling to manage workflows.
+It's automatically installed in the Wasmo DB as part of the DB schema migrations (`ensureSchemaVersion()`).
+
+You only need to install it manually if you’d like to upgrade the Wasmo DB to a later version
+of `absurd`, or want to generate schema migration SQL that does so.
 
 Complete instructions are in the [Absurd Installation] doc.
 
@@ -14,14 +17,6 @@ curl -fsSL \
   https://github.com/earendil-works/absurd/releases/latest/download/absurdctl \
   -o absurdctl
 chmod +x absurdctl
-```
-
-
-```bash
-export PGDATABASE="postgresql://postgres:password@localhost:5432/wasmo_development"
-absurdctl init
-absurdctl schema-version
-absurdctl create-queue default
 ```
 
 [Absurd Installation]: https://earendil-works.github.io/absurd/tools/absurdctl/

--- a/docs/platform/plans/db_schema_migrations.md
+++ b/docs/platform/plans/db_schema_migrations.md
@@ -34,6 +34,22 @@ ON CONFLICT (id) DO NOTHING;
  - `WasmoService.startWasmoService()` calls `ensureSchemaVersion(CURRENT_SCHEMA_VERSION)` right after
    obtaining `wasmoDb` ([code](https://github.com/wasmcomputercompany/wasmo/blob/8c0da2da837a94fe5f7c66640eb51ca2f8dc5140/os/server/ktor/src/jvmMain/kotlin/com/wasmo/ktor/WasmoService.kt#L60)).
 
+### Absurd schema upgrades
+
+absurd is installed as part of the Wasmo DB as part of the automatic schema migrations.
+
+ - Wasmo schema DB version 2 includes absurd schema version 0.3.0 (like `absurdctl init --ref 0.3.0`)
+ - Wasmo schema DB version 3 includes an absurd queue named `default` (like `absurdctl create-queue default`)
+
+For future upgrades, we'll have to generate Wasmo DB schema migration SQL through a command like
+the below, but that requires our PRs to land in absurd, first.
+
+```bash
+export PGDATABASE="postgresql://postgres:password@localhost:5432/wasmo_development"
+TARGET_WASMO_DB_SCHEMA_VERSION=3
+absurdctl migrate --dump-sql > os/server/db/src/jvmMain/resources/migrations/v${TARGET_WASMO_DB_SCHEMA_VERSION}__absurd-$(absurdctl schema-version --target).sql
+```
+
 ### Future options
 
  - The duplication between migrations, `DbFoo` and `FooQueries.kt` is error prone (e.g. typos are only found at runtime). It'd be nice to have a Kotlin DSL or similar to type less and to find more errors at compile time.

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/Migrate.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/Migrate.kt
@@ -52,7 +52,7 @@ suspend fun ensureSchemaVersion(targetVersion: Long = CURRENT_SCHEMA_VERSION) {
 }
 
 private val MigrationNameRegex = Regex("""v(\d+)__.*\.sql""")
-const val CURRENT_SCHEMA_VERSION = 1L
+const val CURRENT_SCHEMA_VERSION = 3L
 
 private data class Migration(
   val version: Int,

--- a/os/server/db/src/jvmMain/resources/migrations/v2__absurdctl_init_ref_0.3.0.sql
+++ b/os/server/db/src/jvmMain/resources/migrations/v2__absurdctl_init_ref_0.3.0.sql
@@ -1,0 +1,1685 @@
+-- Absurd installs a Postgres-native durable workflow system that can be dropped
+-- into an existing database.
+--
+-- It bootstraps the `absurd` schema and required extensions so that jobs, runs,
+-- checkpoints, and workflow events all live alongside application data without
+-- external services.
+--
+-- Each queue is materialized as its own set of tables that share a prefix:
+-- * `t_` for tasks (what is to be run)
+-- * `r_` for runs (attempts to run a task)
+-- * `c_` for checkpoints (saved states)
+-- * `e_` for emitted events
+-- * `w_` for wait registrations
+--
+-- `create_queue`, `drop_queue`, and `list_queues` provide the management
+-- surface for provisioning queues safely.
+--
+-- Task execution flows through `spawn_task`, which records the logical task and
+-- its first run, and `claim_task`, which hands work to workers with leasing
+-- semantics, state transitions, and cancellation checks.  Runtime routines
+-- such as `complete_run`, `schedule_run`, and `fail_run` advance or retry work,
+-- enforce attempt accounting, and keep the task and run tables synchronized.
+--
+-- Long-running or event-driven workflows rely on lightweight persistence
+-- primitives.  Checkpoint helpers (`set_task_checkpoint_state`,
+-- `get_task_checkpoint_state`, `get_task_checkpoint_states`) write arbitrary
+-- JSON payloads keyed by task and step, while `await_event` and `emit_event`
+-- coordinate sleepers and external signals so that tasks can suspend and resume
+-- without losing context.  Events are uniquely indexed and use first-write-wins
+-- semantics: the first emission per name is cached, later emits are ignored.
+
+create extension if not exists "uuid-ossp";
+
+create schema if not exists absurd;
+
+-- Returns either the actual current timestamp or a fake one if
+-- the session sets `absurd.fake_now`.  This lets tests control time.
+create function absurd.current_time ()
+  returns timestamptz
+  language plpgsql
+  volatile
+as $$
+declare
+v_fake text;
+begin
+  v_fake := current_setting('absurd.fake_now', true);
+  if v_fake is not null and length(trim(v_fake)) > 0 then
+    return v_fake::timestamptz;
+end if;
+
+return clock_timestamp();
+end;
+$$;
+
+create table if not exists absurd.queues (
+                                           queue_name text primary key,
+                                           created_at timestamptz not null default absurd.current_time()
+  );
+
+-- Returns the Absurd schema release version baked into this SQL file.
+-- During development this is usually "main" and release automation replaces
+-- it with the actual tag version.
+
+create or replace function absurd.get_schema_version ()
+  returns text
+  language sql
+as $$
+select 'main'::text;
+$$;
+
+-- Queue names are used in generated table/index identifiers.
+-- We intentionally cap UTF-8 byte length so generated explicit index names
+-- (for instance r_<queue>_sai) stay within PostgreSQL's 63-byte identifier
+-- limit. Character set is otherwise delegated to PostgreSQL quoted-ident rules.
+create function absurd.validate_queue_name (p_queue_name text)
+  returns text
+  language plpgsql
+as $$
+begin
+  if p_queue_name is null or length(trim(p_queue_name)) = 0 then
+    raise exception 'Queue name must be provided';
+end if;
+
+  if octet_length(p_queue_name) > 57 then
+    raise exception 'Queue name "%" is too long (max 57 bytes).', p_queue_name;
+end if;
+
+return p_queue_name;
+end;
+$$;
+
+create function absurd.ensure_queue_tables (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+begin
+  perform absurd.validate_queue_name(p_queue_name);
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid primary key,
+      task_name text not null,
+      params jsonb not null,
+      headers jsonb,
+      retry_strategy jsonb,
+      max_attempts integer,
+      cancellation jsonb,
+      enqueue_at timestamptz not null default absurd.current_time(),
+      first_started_at timestamptz,
+      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+      attempts integer not null default 0,
+      last_attempt_run uuid,
+      completed_payload jsonb,
+      cancelled_at timestamptz,
+      idempotency_key text unique
+   ) with (fillfactor=70)',
+  't_' || p_queue_name
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      run_id uuid primary key,
+      task_id uuid not null,
+      attempt integer not null,
+      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+      claimed_by text,
+      claim_expires_at timestamptz,
+      available_at timestamptz not null,
+      wake_event text,
+      event_payload jsonb,
+      started_at timestamptz,
+      completed_at timestamptz,
+      failed_at timestamptz,
+      result jsonb,
+      failure_reason jsonb,
+      created_at timestamptz not null default absurd.current_time()
+   ) with (fillfactor=70)',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid not null,
+      checkpoint_name text not null,
+      state jsonb,
+      status text not null default ''committed'',
+      owner_run_id uuid,
+      updated_at timestamptz not null default absurd.current_time(),
+      primary key (task_id, checkpoint_name)
+   ) with (fillfactor=70)',
+  'c_' || p_queue_name
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      event_name text primary key,
+      payload jsonb,
+      emitted_at timestamptz not null default absurd.current_time()
+   )',
+  'e_' || p_queue_name
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid not null,
+      run_id uuid not null,
+      step_name text not null,
+      event_name text not null,
+      timeout_at timestamptz,
+      created_at timestamptz not null default absurd.current_time(),
+      primary key (run_id, step_name)
+   )',
+  'w_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (state, available_at)',
+  ('r_' || p_queue_name) || '_sai',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (task_id)',
+  ('r_' || p_queue_name) || '_ti',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (claim_expires_at)
+    where state = ''running''
+      and claim_expires_at is not null',
+  ('r_' || p_queue_name) || '_cei',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (event_name)',
+  ('w_' || p_queue_name) || '_eni',
+  'w_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (task_id)',
+  ('w_' || p_queue_name) || '_ti',
+  'w_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (emitted_at)',
+  ('e_' || p_queue_name) || '_eai',
+  'e_' || p_queue_name
+        );
+end;
+$$;
+
+-- Creates the queue with the given name.
+--
+-- If the table already exists, the function returns silently.
+create function absurd.create_queue (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+begin
+insert into absurd.queues (queue_name)
+values (p_queue_name);
+exception when unique_violation then
+    return;
+end;
+
+  perform absurd.ensure_queue_tables(p_queue_name);
+end;
+$$;
+
+-- Drop a queue if it exists.
+-- We intentionally don't validate the provided name here so legacy queues
+-- created under older naming rules can still be removed.
+create function absurd.drop_queue (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+declare
+v_existing_queue text;
+begin
+select queue_name into v_existing_queue
+from absurd.queues
+where queue_name = p_queue_name;
+
+if v_existing_queue is null then
+    return;
+end if;
+
+execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'e_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'c_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'r_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 't_' || p_queue_name);
+
+delete from absurd.queues where queue_name = p_queue_name;
+end;
+$$;
+
+-- Lists all queues that currently exist.
+create function absurd.list_queues ()
+  returns table (queue_name text)
+  language sql
+  as $$
+select queue_name from absurd.queues order by queue_name;
+$$;
+
+-- Returns the current state and terminal payload (if any) for a task.
+--
+-- Non-terminal states (pending/running/sleeping) return result/failure_reason
+-- as NULL. Completed tasks expose completed_payload as result. Failed tasks
+-- expose the last run failure_reason.
+create function absurd.get_task_result (
+  p_queue_name text,
+  p_task_id uuid
+)
+  returns table (
+                  task_id uuid,
+                  state text,
+                  result jsonb,
+                  failure_reason jsonb
+                )
+  language plpgsql
+as $$
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+return query execute format(
+    'select t.task_id,
+            t.state,
+            case when t.state = ''completed'' then t.completed_payload else null end as result,
+            case when t.state = ''failed'' then r.failure_reason else null end as failure_reason
+       from absurd.%I t
+       left join absurd.%I r on r.run_id = t.last_attempt_run
+      where t.task_id = $1',
+    't_' || p_queue_name,
+    'r_' || p_queue_name
+  ) using p_task_id;
+end;
+$$;
+
+-- Spawns a given task in a queue.
+--
+-- If an idempotency_key is provided in p_options, the function will check if a task
+-- with that key already exists. If so, it returns the existing task_id with run_id
+-- and attempt set to NULL to signal "already exists". This is race-safe via
+-- INSERT ... ON CONFLICT DO NOTHING.
+create function absurd.spawn_task (
+  p_queue_name text,
+  p_task_name text,
+  p_params jsonb,
+  p_options jsonb default '{}'::jsonb
+)
+  returns table (
+                  task_id uuid,
+                  run_id uuid,
+                  attempt integer,
+                  created boolean
+                )
+  language plpgsql
+as $$
+declare
+v_task_id uuid := absurd.portable_uuidv7();
+  v_run_id uuid := absurd.portable_uuidv7();
+  v_attempt integer := 1;
+  v_headers jsonb;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_cancellation jsonb;
+  v_idempotency_key text;
+  v_existing_task_id uuid;
+  v_row_count integer;
+  v_now timestamptz := absurd.current_time();
+  v_params jsonb := coalesce(p_params, 'null'::jsonb);
+begin
+  if p_task_name is null or length(trim(p_task_name)) = 0 then
+    raise exception 'task_name must be provided';
+end if;
+
+  if p_options is not null then
+    v_headers := p_options->'headers';
+    v_retry_strategy := p_options->'retry_strategy';
+    if p_options ? 'max_attempts' then
+      v_max_attempts := (p_options->>'max_attempts')::int;
+      if v_max_attempts is not null and v_max_attempts < 1 then
+        raise exception 'max_attempts must be >= 1';
+end if;
+end if;
+    v_cancellation := p_options->'cancellation';
+    v_idempotency_key := p_options->>'idempotency_key';
+end if;
+
+  -- If idempotency_key is provided, use INSERT ... ON CONFLICT DO NOTHING
+  if v_idempotency_key is not null then
+    execute format(
+      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
+       on conflict (idempotency_key) do nothing',
+      't_' || p_queue_name
+    )
+    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+
+get diagnostics v_row_count = row_count;
+
+if v_row_count = 0 then
+      -- Task already exists, look up existing task info
+      execute format(
+        'select task_id, last_attempt_run, attempts from absurd.%I where idempotency_key = $1',
+        't_' || p_queue_name
+      )
+      into v_existing_task_id, v_run_id, v_attempt
+      using v_idempotency_key;
+
+return query select v_existing_task_id, v_run_id, v_attempt, false;
+return;
+end if;
+else
+    -- No idempotency key, insert normally
+    execute format(
+      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, null)',
+      't_' || p_queue_name
+    )
+    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id;
+end if;
+
+execute format(
+  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+   values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+  'r_' || p_queue_name
+        )
+  using v_run_id, v_task_id, v_attempt, v_now;
+
+return query select v_task_id, v_run_id, v_attempt, true;
+end;
+$$;
+
+-- Workers call this to reserve a task from a given queue
+-- for a given reservation period in seconds.
+create function absurd.claim_task (
+  p_queue_name text,
+  p_worker_id text,
+  p_claim_timeout integer default 30,
+  p_qty integer default 1
+)
+  returns table (
+                  run_id uuid,
+                  task_id uuid,
+                  attempt integer,
+                  task_name text,
+                  params jsonb,
+                  retry_strategy jsonb,
+                  max_attempts integer,
+                  headers jsonb,
+                  wake_event text,
+                  event_payload jsonb
+                )
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_claim_timeout integer := greatest(coalesce(p_claim_timeout, 30), 0);
+  v_worker_id text := coalesce(nullif(p_worker_id, ''), 'worker');
+  v_qty integer := greatest(coalesce(p_qty, 1), 1);
+  v_claim_until timestamptz := null;
+  v_sql text;
+  v_expired_run record;
+  v_cancel_candidate record;
+  v_expired_sweep_limit integer;
+begin
+  if v_claim_timeout > 0 then
+    v_claim_until := v_now + make_interval(secs => v_claim_timeout);
+end if;
+
+  -- Keep claim polling work bounded: process at most v_qty expired leases
+  -- per claim call.
+  v_expired_sweep_limit := greatest(v_qty, 1);
+
+  -- Apply cancellation rules before claiming.
+  --
+  -- Use cancel_task() so lock order stays consistent (runs first, task second)
+  -- with complete_run()/fail_run().
+for v_cancel_candidate in
+    execute format(
+      'select task_id
+         from absurd.%I
+        where state in (''pending'', ''sleeping'', ''running'')
+          and (
+            (
+              (cancellation->>''max_delay'')::bigint is not null
+              and first_started_at is null
+              and extract(epoch from ($1 - enqueue_at)) >= (cancellation->>''max_delay'')::bigint
+            )
+            or
+            (
+              (cancellation->>''max_duration'')::bigint is not null
+              and first_started_at is not null
+              and extract(epoch from ($1 - first_started_at)) >= (cancellation->>''max_duration'')::bigint
+            )
+          )
+        order by task_id',
+      't_' || p_queue_name
+    )
+  using v_now
+  loop
+    perform absurd.cancel_task(p_queue_name, v_cancel_candidate.task_id);
+end loop;
+
+for v_expired_run in
+    execute format(
+      'select run_id,
+              claimed_by,
+              claim_expires_at,
+              attempt
+         from absurd.%I
+        where state = ''running''
+          and claim_expires_at is not null
+          and claim_expires_at <= $1
+        order by claim_expires_at, run_id
+        limit $2
+        for update skip locked',
+      'r_' || p_queue_name
+    )
+  using v_now, v_expired_sweep_limit
+  loop
+    perform absurd.fail_run(
+      p_queue_name,
+      v_expired_run.run_id,
+      jsonb_strip_nulls(jsonb_build_object(
+        'name', '$ClaimTimeout',
+        'message', 'worker did not finish task within claim interval',
+        'workerId', v_expired_run.claimed_by,
+        'claimExpiredAt', v_expired_run.claim_expires_at,
+        'attempt', v_expired_run.attempt
+      )),
+      null
+    );
+end loop;
+
+  v_sql := format(
+    'with candidate as (
+        select r.run_id
+          from absurd.%1$I r
+          join absurd.%2$I t on t.task_id = r.task_id
+         where r.state in (''pending'', ''sleeping'')
+           and t.state in (''pending'', ''sleeping'', ''running'')
+           and r.available_at <= $1
+         order by r.available_at, r.run_id
+         limit $2
+         for update skip locked
+     ),
+     updated as (
+        update absurd.%1$I r
+           set state = ''running'',
+               claimed_by = $3,
+               claim_expires_at = $4,
+               started_at = $1,
+               available_at = $1
+         where run_id in (select run_id from candidate)
+         returning r.run_id, r.task_id, r.attempt
+     ),
+     task_upd as (
+        update absurd.%2$I t
+           set state = ''running'',
+               attempts = greatest(t.attempts, u.attempt),
+               first_started_at = coalesce(t.first_started_at, $1),
+               last_attempt_run = u.run_id
+          from updated u
+         where t.task_id = u.task_id
+         returning t.task_id
+     ),
+     wait_cleanup as (
+        delete from absurd.%3$I w
+         using updated u
+        where w.run_id = u.run_id
+          and w.timeout_at is not null
+          and w.timeout_at <= $1
+        returning w.run_id
+     )
+     select
+       u.run_id,
+       u.task_id,
+       u.attempt,
+       t.task_name,
+       t.params,
+       t.retry_strategy,
+       t.max_attempts,
+      t.headers,
+      r.wake_event,
+      r.event_payload
+     from updated u
+     join absurd.%1$I r on r.run_id = u.run_id
+     join absurd.%2$I t on t.task_id = u.task_id
+     order by r.available_at, u.run_id',
+    'r_' || p_queue_name,
+    't_' || p_queue_name,
+    'w_' || p_queue_name
+  );
+
+return query execute v_sql using v_now, v_qty, v_worker_id, v_claim_until;
+end;
+$$;
+
+-- Markes a run as completed
+create function absurd.complete_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_state jsonb default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_task_id uuid;
+  v_state text;
+  v_now timestamptz := absurd.current_time();
+begin
+execute format(
+  'select task_id, state
+     from absurd.%I
+    where run_id = $1
+    for update',
+  'r_' || p_queue_name
+        )
+  into v_task_id, v_state
+  using p_run_id;
+
+if v_task_id is null then
+    raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_state <> 'running' then
+    raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = ''completed'',
+          completed_at = $2,
+          result = $3
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, v_now, p_state;
+
+execute format(
+  'update absurd.%I
+      set state = ''completed'',
+          completed_payload = $2,
+          last_attempt_run = $3
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using v_task_id, p_state, p_run_id;
+
+execute format(
+  'delete from absurd.%I where run_id = $1',
+  'w_' || p_queue_name
+        ) using p_run_id;
+end;
+$$;
+
+create function absurd.schedule_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_wake_at timestamptz
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_task_id uuid;
+begin
+execute format(
+  'select task_id
+     from absurd.%I
+    where run_id = $1
+      and state = ''running''
+    for update',
+  'r_' || p_queue_name
+        )
+  into v_task_id
+  using p_run_id;
+
+if v_task_id is null then
+    raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = ''sleeping'',
+          claimed_by = null,
+          claim_expires_at = null,
+          available_at = $2,
+          wake_event = null
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, p_wake_at;
+
+execute format(
+  'update absurd.%I
+      set state = ''sleeping''
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using v_task_id;
+end;
+$$;
+
+create function absurd.fail_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_reason jsonb,
+  p_retry_at timestamptz default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_task_id uuid;
+  v_attempt integer;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_now timestamptz := absurd.current_time();
+  v_next_attempt integer;
+  v_delay_seconds double precision := 0;
+  v_next_available timestamptz;
+  v_retry_kind text;
+  v_base double precision;
+  v_factor double precision;
+  v_max_seconds double precision;
+  v_first_started timestamptz;
+  v_cancellation jsonb;
+  v_max_duration bigint;
+  v_task_cancel boolean := false;
+  v_new_run_id uuid;
+  v_task_state_after text;
+  v_recorded_attempt integer;
+  v_last_attempt_run uuid := p_run_id;
+  v_cancelled_at timestamptz := null;
+begin
+execute format(
+  'select r.task_id, r.attempt
+     from absurd.%I r
+    where r.run_id = $1
+      and r.state in (''running'', ''sleeping'')
+    for update',
+  'r_' || p_queue_name
+        )
+  into v_task_id, v_attempt
+  using p_run_id;
+
+if v_task_id is null then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'select retry_strategy, max_attempts, first_started_at, cancellation
+     from absurd.%I
+    where task_id = $1
+    for update',
+  't_' || p_queue_name
+        )
+  into v_retry_strategy, v_max_attempts, v_first_started, v_cancellation
+  using v_task_id;
+
+execute format(
+  'update absurd.%I
+      set state = ''failed'',
+          wake_event = null,
+          failed_at = $2,
+          failure_reason = $3
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, v_now, p_reason;
+
+v_next_attempt := v_attempt + 1;
+  v_task_state_after := 'failed';
+  v_recorded_attempt := v_attempt;
+
+  if v_max_attempts is null or v_next_attempt <= v_max_attempts then
+    if p_retry_at is not null then
+      v_next_available := p_retry_at;
+else
+      v_retry_kind := coalesce(v_retry_strategy->>'kind', 'none');
+      if v_retry_kind = 'fixed' then
+        v_base := coalesce((v_retry_strategy->>'base_seconds')::double precision, 60);
+        v_delay_seconds := v_base;
+      elsif v_retry_kind = 'exponential' then
+        v_base := coalesce((v_retry_strategy->>'base_seconds')::double precision, 30);
+        v_factor := coalesce((v_retry_strategy->>'factor')::double precision, 2);
+        v_delay_seconds := v_base * power(v_factor, greatest(v_attempt - 1, 0));
+        v_max_seconds := (v_retry_strategy->>'max_seconds')::double precision;
+        if v_max_seconds is not null then
+          v_delay_seconds := least(v_delay_seconds, v_max_seconds);
+end if;
+else
+        v_delay_seconds := 0;
+end if;
+      v_next_available := v_now + (v_delay_seconds * interval '1 second');
+end if;
+
+    if v_next_available < v_now then
+      v_next_available := v_now;
+end if;
+
+    if v_cancellation is not null then
+      v_max_duration := (v_cancellation->>'max_duration')::bigint;
+      if v_max_duration is not null and v_first_started is not null then
+        if extract(epoch from (v_next_available - v_first_started)) >= v_max_duration then
+          v_task_cancel := true;
+end if;
+end if;
+end if;
+
+    if not v_task_cancel then
+      v_task_state_after := case when v_next_available > v_now then 'sleeping' else 'pending' end;
+      v_new_run_id := absurd.portable_uuidv7();
+      v_recorded_attempt := v_next_attempt;
+      v_last_attempt_run := v_new_run_id;
+execute format(
+  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+   values ($1, $2, $3, $4, $5, null, null, null, null)',
+  'r_' || p_queue_name
+        )
+  using v_new_run_id, v_task_id, v_next_attempt, v_task_state_after, v_next_available;
+end if;
+end if;
+
+  if v_task_cancel then
+    v_task_state_after := 'cancelled';
+    v_cancelled_at := v_now;
+    v_recorded_attempt := greatest(v_recorded_attempt, v_attempt);
+    v_last_attempt_run := p_run_id;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = $2,
+          attempts = greatest(attempts, $3),
+          last_attempt_run = $4,
+          cancelled_at = coalesce(cancelled_at, $5)
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using v_task_id, v_task_state_after, v_recorded_attempt, v_last_attempt_run, v_cancelled_at;
+
+execute format(
+  'delete from absurd.%I where run_id = $1',
+  'w_' || p_queue_name
+        ) using p_run_id;
+end;
+$$;
+
+-- Retries a failed task either by extending attempts on the same task or by
+-- spawning a brand new task from the original inputs.
+--
+-- Options:
+-- - spawn_new (boolean, default false): create a new task instead of retrying in-place.
+-- - max_attempts (integer, optional): for in-place retry, defaults to
+--   coalesce(current max_attempts, current attempts) + 1 and must be greater
+--   than current attempts; for spawn_new it overrides copied max_attempts on
+--   the new task.
+create function absurd.retry_task (
+  p_queue_name text,
+  p_task_id uuid,
+  p_options jsonb default '{}'::jsonb
+)
+  returns table (
+                  task_id uuid,
+                  run_id uuid,
+                  attempt integer,
+                  created boolean
+                )
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_spawn_new boolean := false;
+  v_requested_max_attempts integer;
+
+  v_task_name text;
+  v_params jsonb;
+  v_headers jsonb;
+  v_retry_strategy jsonb;
+  v_task_max_attempts integer;
+  v_cancellation jsonb;
+  v_task_attempts integer;
+  v_task_state text;
+
+  v_new_run_id uuid;
+  v_new_attempt integer;
+  v_spawn_options jsonb;
+begin
+  if p_options is not null then
+    if p_options ? 'spawn_new' then
+      v_spawn_new := coalesce((p_options->>'spawn_new')::boolean, false);
+end if;
+    if p_options ? 'max_attempts' then
+      v_requested_max_attempts := (p_options->>'max_attempts')::int;
+      if v_requested_max_attempts is not null and v_requested_max_attempts < 1 then
+        raise exception 'max_attempts must be >= 1';
+end if;
+end if;
+end if;
+
+execute format(
+  'select task_name,
+          params,
+          headers,
+          retry_strategy,
+          max_attempts,
+          cancellation,
+          attempts,
+          state
+     from absurd.%I
+    where task_id = $1
+    for update',
+  't_' || p_queue_name
+        )
+  into v_task_name,
+    v_params,
+    v_headers,
+    v_retry_strategy,
+    v_task_max_attempts,
+    v_cancellation,
+    v_task_attempts,
+    v_task_state
+  using p_task_id;
+
+if v_task_state is null then
+    raise exception 'Task "%" not found in queue "%"', p_task_id, p_queue_name;
+end if;
+
+  if v_task_state <> 'failed' then
+    raise exception 'Task "%" is not currently failed in queue "%"', p_task_id, p_queue_name;
+end if;
+
+  if v_spawn_new then
+    v_spawn_options := jsonb_strip_nulls(jsonb_build_object(
+      'headers', v_headers,
+      'retry_strategy', v_retry_strategy,
+      'max_attempts', coalesce(v_requested_max_attempts, v_task_max_attempts),
+      'cancellation', v_cancellation
+    ));
+
+return query
+select s.task_id, s.run_id, s.attempt, s.created
+from absurd.spawn_task(p_queue_name, v_task_name, v_params, v_spawn_options) s;
+return;
+end if;
+
+  if v_requested_max_attempts is null then
+    v_requested_max_attempts := coalesce(v_task_max_attempts, v_task_attempts) + 1;
+end if;
+
+  if v_requested_max_attempts <= v_task_attempts then
+    raise exception 'max_attempts (%) must be greater than current attempts (%)',
+      v_requested_max_attempts,
+      v_task_attempts;
+end if;
+
+  v_new_run_id := absurd.portable_uuidv7();
+  v_new_attempt := v_task_attempts + 1;
+
+execute format(
+  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+   values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+  'r_' || p_queue_name
+        )
+  using v_new_run_id, p_task_id, v_new_attempt, v_now;
+
+execute format(
+  'update absurd.%I
+      set state = ''pending'',
+          attempts = greatest(attempts, $2),
+          max_attempts = $3,
+          last_attempt_run = $4,
+          cancelled_at = null
+    where task_id = $1',
+  't_' || p_queue_name
+        )
+  using p_task_id, v_new_attempt, v_requested_max_attempts, v_new_run_id;
+
+return query select p_task_id, v_new_run_id, v_new_attempt, false;
+end;
+$$;
+
+create function absurd.set_task_checkpoint_state (
+  p_queue_name text,
+  p_task_id uuid,
+  p_step_name text,
+  p_state jsonb,
+  p_owner_run uuid,
+  p_extend_claim_by integer default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_new_attempt integer;
+  v_existing_attempt integer;
+  v_existing_owner uuid;
+  v_task_state text;
+  v_run_state text;
+begin
+  if p_step_name is null or length(trim(p_step_name)) = 0 then
+    raise exception 'step_name must be provided';
+end if;
+
+execute format(
+  'select r.attempt, r.state, t.state
+     from absurd.%I r
+     join absurd.%I t on t.task_id = r.task_id
+    where r.run_id = $1',
+  'r_' || p_queue_name,
+  't_' || p_queue_name
+        )
+  into v_new_attempt, v_run_state, v_task_state
+  using p_owner_run;
+
+if v_new_attempt is null then
+    raise exception 'Run "%" not found for checkpoint', p_owner_run;
+end if;
+
+  if v_task_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+end if;
+
+  if v_run_state = 'failed' then
+    raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_owner_run, p_queue_name);
+end if;
+
+  -- Extend the claim if requested
+  if p_extend_claim_by is not null and p_extend_claim_by > 0 then
+    execute format(
+      'update absurd.%I
+          set claim_expires_at = $2 + make_interval(secs => $3)
+        where run_id = $1
+          and state = ''running''
+          and claim_expires_at is not null',
+      'r_' || p_queue_name
+    )
+    using p_owner_run, v_now, p_extend_claim_by;
+end if;
+
+execute format(
+  'select c.owner_run_id,
+          r.attempt
+     from absurd.%I c
+     left join absurd.%I r on r.run_id = c.owner_run_id
+    where c.task_id = $1
+      and c.checkpoint_name = $2',
+  'c_' || p_queue_name,
+  'r_' || p_queue_name
+        )
+  into v_existing_owner, v_existing_attempt
+  using p_task_id, p_step_name;
+
+if v_existing_owner is null or v_existing_attempt is null or v_new_attempt >= v_existing_attempt then
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, $3, ''committed'', $4, $5)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, p_state, p_owner_run, v_now;
+end if;
+end;
+$$;
+
+create function absurd.extend_claim (
+  p_queue_name text,
+  p_run_id uuid,
+  p_extend_by integer
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_task_state text;
+  v_run_state text;
+  v_claim_expires_at timestamptz;
+begin
+  if p_extend_by is null or p_extend_by <= 0 then
+    raise exception 'extend_by must be > 0';
+end if;
+
+execute format(
+  'select r.state,
+          r.claim_expires_at,
+          t.state
+     from absurd.%I r
+     join absurd.%I t on t.task_id = r.task_id
+    where r.run_id = $1
+    for update',
+  'r_' || p_queue_name,
+  't_' || p_queue_name
+        )
+  into v_run_state, v_claim_expires_at, v_task_state
+  using p_run_id;
+
+if v_run_state is null then
+    raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_task_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+end if;
+
+  if v_run_state <> 'running' then
+    if v_run_state = 'failed' then
+      raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+end if;
+    raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_claim_expires_at is null then
+    raise exception 'Run "%" does not have an active claim in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'update absurd.%I
+      set claim_expires_at = $2 + make_interval(secs => $3)
+    where run_id = $1',
+  'r_' || p_queue_name
+        )
+  using p_run_id, v_now, p_extend_by;
+end;
+$$;
+
+-- Returns one checkpoint by name. By default only committed checkpoint rows
+-- are visible; pass p_include_pending = true to include pending rows.
+create function absurd.get_task_checkpoint_state (
+  p_queue_name text,
+  p_task_id uuid,
+  p_step_name text,
+  p_include_pending boolean default false
+)
+  returns table (
+                  checkpoint_name text,
+                  state jsonb,
+                  status text,
+                  owner_run_id uuid,
+                  updated_at timestamptz
+                )
+  language plpgsql
+as $$
+begin
+return query execute format(
+    'select checkpoint_name, state, status, owner_run_id, updated_at
+       from absurd.%I
+      where task_id = $1
+        and checkpoint_name = $2
+        and ($3 or status = ''committed'')',
+    'c_' || p_queue_name
+  ) using p_task_id, p_step_name, coalesce(p_include_pending, false);
+end;
+$$;
+
+-- Returns committed checkpoints visible to the given run. The run must belong
+-- to the provided task, and checkpoints from later attempts are hidden.
+create function absurd.get_task_checkpoint_states (
+  p_queue_name text,
+  p_task_id uuid,
+  p_run_id uuid
+)
+  returns table (
+                  checkpoint_name text,
+                  state jsonb,
+                  status text,
+                  owner_run_id uuid,
+                  updated_at timestamptz
+                )
+  language plpgsql
+as $$
+declare
+v_run_task_id uuid;
+  v_run_attempt integer;
+begin
+execute format(
+  'select task_id, attempt
+     from absurd.%I
+    where run_id = $1',
+  'r_' || p_queue_name
+        )
+  into v_run_task_id, v_run_attempt
+  using p_run_id;
+
+if v_run_task_id is null then
+    raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_run_task_id <> p_task_id then
+    raise exception 'Run "%" does not belong to task "%" in queue "%"', p_run_id, p_task_id, p_queue_name;
+end if;
+
+return query execute format(
+    'select c.checkpoint_name,
+            c.state,
+            c.status,
+            c.owner_run_id,
+            c.updated_at
+       from absurd.%1$I c
+       left join absurd.%2$I owner_run on owner_run.run_id = c.owner_run_id
+      where c.task_id = $1
+        and c.status = ''committed''
+        and (owner_run.attempt is null or owner_run.attempt <= $2)
+      order by c.updated_at asc',
+    'c_' || p_queue_name,
+    'r_' || p_queue_name
+  ) using p_task_id, v_run_attempt;
+end;
+$$;
+
+create function absurd.await_event (
+  p_queue_name text,
+  p_task_id uuid,
+  p_run_id uuid,
+  p_step_name text,
+  p_event_name text,
+  p_timeout integer default null
+)
+  returns table (
+                  should_suspend boolean,
+                  payload jsonb
+                )
+  language plpgsql
+as $$
+declare
+v_run_state text;
+  v_existing_payload jsonb;
+  v_event_payload jsonb;
+  v_checkpoint_payload jsonb;
+  v_resolved_payload jsonb;
+  v_timeout_at timestamptz;
+  v_available_at timestamptz;
+  v_now timestamptz := absurd.current_time();
+  v_task_state text;
+  v_wake_event text;
+begin
+  if p_event_name is null or length(trim(p_event_name)) = 0 then
+    raise exception 'event_name must be provided';
+end if;
+
+  if p_timeout is not null then
+    if p_timeout < 0 then
+      raise exception 'timeout must be non-negative';
+end if;
+    v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
+end if;
+
+  v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
+
+execute format(
+  'select state
+     from absurd.%I
+    where task_id = $1
+      and checkpoint_name = $2',
+  'c_' || p_queue_name
+        )
+  into v_checkpoint_payload
+  using p_task_id, p_step_name;
+
+if v_checkpoint_payload is not null then
+    return query select false, v_checkpoint_payload;
+return;
+end if;
+
+  -- Ensure a row exists for this event so we can take a row-level lock.
+  --
+  -- We use payload IS NULL as the sentinel for "not emitted yet".  emit_event
+  -- always writes a non-NULL payload (at minimum JSON null).
+  --
+  -- Lock ordering is important to avoid deadlocks: await_event locks the event
+  -- row first (FOR SHARE) and then the run row (FOR UPDATE).  emit_event
+  -- naturally locks the event row via its UPSERT before touching waits/runs.
+execute format(
+  'insert into absurd.%I (event_name, payload, emitted_at)
+   values ($1, null, ''epoch''::timestamptz)
+   on conflict (event_name) do nothing',
+  'e_' || p_queue_name
+        ) using p_event_name;
+
+execute format(
+  'select 1
+     from absurd.%I
+    where event_name = $1
+    for share',
+  'e_' || p_queue_name
+        ) using p_event_name;
+
+execute format(
+  'select r.state, r.event_payload, r.wake_event, t.state
+     from absurd.%I r
+     join absurd.%I t on t.task_id = r.task_id
+    where r.run_id = $1
+    for update',
+  'r_' || p_queue_name,
+  't_' || p_queue_name
+        )
+  into v_run_state, v_existing_payload, v_wake_event, v_task_state
+  using p_run_id;
+
+if v_run_state is null then
+    raise exception 'Run "%" not found while awaiting event', p_run_id;
+end if;
+
+  if v_task_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+end if;
+
+execute format(
+  'select payload
+     from absurd.%I
+    where event_name = $1',
+  'e_' || p_queue_name
+        )
+  into v_event_payload
+  using p_event_name;
+
+if v_existing_payload is not null then
+    execute format(
+      'update absurd.%I
+          set event_payload = null
+        where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+
+    if v_event_payload is not null and v_event_payload = v_existing_payload then
+      v_resolved_payload := v_existing_payload;
+end if;
+end if;
+
+  if v_run_state <> 'running' then
+    raise exception 'Run "%" must be running to await events', p_run_id;
+end if;
+
+  if v_resolved_payload is null and v_event_payload is not null then
+    v_resolved_payload := v_event_payload;
+end if;
+
+  if v_resolved_payload is not null then
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, $3, ''committed'', $4, $5)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, v_resolved_payload, p_run_id, v_now;
+return query select false, v_resolved_payload;
+return;
+end if;
+
+  -- Detect if we resumed due to timeout: wake_event matches and payload is null
+  if v_resolved_payload is null and v_wake_event = p_event_name and v_existing_payload is null then
+    -- Resumed due to timeout; don't re-sleep and don't create a new wait
+    execute format(
+      'update absurd.%I set wake_event = null where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+return query select false, null::jsonb;
+return;
+end if;
+
+execute format(
+  'insert into absurd.%I (task_id, run_id, step_name, event_name, timeout_at, created_at)
+   values ($1, $2, $3, $4, $5, $6)
+   on conflict (run_id, step_name)
+   do update set event_name = excluded.event_name,
+                 timeout_at = excluded.timeout_at,
+                 created_at = excluded.created_at',
+  'w_' || p_queue_name
+        ) using p_task_id, p_run_id, p_step_name, p_event_name, v_timeout_at, v_now;
+
+execute format(
+  'update absurd.%I
+      set state = ''sleeping'',
+          claimed_by = null,
+          claim_expires_at = null,
+          available_at = $3,
+          wake_event = $2,
+          event_payload = null
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, p_event_name, v_available_at;
+
+execute format(
+  'update absurd.%I
+      set state = ''sleeping''
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using p_task_id;
+
+return query select true, null::jsonb;
+return;
+end;
+$$;
+
+create function absurd.emit_event (
+  p_queue_name text,
+  p_event_name text,
+  p_payload jsonb default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_payload jsonb := coalesce(p_payload, 'null'::jsonb);
+  v_emit_applied integer;
+begin
+  if p_event_name is null or length(trim(p_event_name)) = 0 then
+    raise exception 'event_name must be provided';
+end if;
+
+  -- Events are immutable once emitted: first write wins.
+  --
+  -- await_event() may pre-create a row with payload=NULL as a "not emitted"
+  -- sentinel. We allow exactly one transition NULL -> JSON payload.
+execute format(
+  'insert into absurd.%1$I as e (event_name, payload, emitted_at)
+   values ($1, $2, $3)
+   on conflict (event_name)
+   do update set payload = excluded.payload,
+                 emitted_at = excluded.emitted_at
+    where e.payload is null',
+  'e_' || p_queue_name
+        ) using p_event_name, v_payload, v_now;
+
+get diagnostics v_emit_applied = row_count;
+
+-- Event was already emitted earlier; do not overwrite cached payload or
+-- re-run wakeup side effects.
+if v_emit_applied = 0 then
+    return;
+end if;
+
+execute format(
+  'with expired_waits as (
+      delete from absurd.%1$I w
+       where w.event_name = $1
+         and w.timeout_at is not null
+         and w.timeout_at <= $2
+       returning w.run_id
+   ),
+   affected as (
+      select run_id, task_id, step_name
+        from absurd.%1$I
+       where event_name = $1
+         and (timeout_at is null or timeout_at > $2)
+   ),
+   updated_runs as (
+      update absurd.%2$I r
+         set state = ''pending'',
+             available_at = $2,
+             wake_event = null,
+             event_payload = $3,
+             claimed_by = null,
+             claim_expires_at = null
+       where r.run_id in (select run_id from affected)
+         and r.state = ''sleeping''
+       returning r.run_id, r.task_id
+   ),
+   checkpoint_upd as (
+      insert into absurd.%3$I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+      select a.task_id, a.step_name, $3, ''committed'', a.run_id, $2
+        from affected a
+        join updated_runs ur on ur.run_id = a.run_id
+      on conflict (task_id, checkpoint_name)
+      do update set state = excluded.state,
+                    status = excluded.status,
+                    owner_run_id = excluded.owner_run_id,
+                    updated_at = excluded.updated_at
+   ),
+   updated_tasks as (
+      update absurd.%4$I t
+         set state = ''pending''
+       where t.task_id in (select task_id from updated_runs)
+       returning task_id
+   )
+   delete from absurd.%5$I w
+    where w.event_name = $1
+      and w.run_id in (select run_id from updated_runs)',
+  'w_' || p_queue_name,
+  'r_' || p_queue_name,
+  'c_' || p_queue_name,
+  't_' || p_queue_name,
+  'w_' || p_queue_name
+        ) using p_event_name, v_now, v_payload;
+end;
+$$;
+
+-- Manually cancels a task by its task_id.
+-- Sets the task state to 'cancelled' and prevents any future runs.
+-- Currently running code will detect cancellation at the next checkpoint or heartbeat.
+create function absurd.cancel_task (
+  p_queue_name text,
+  p_task_id uuid
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_task_state text;
+begin
+  -- Lock active runs before the task row so cancel_task() uses the same
+  -- lock acquisition order as complete_run()/fail_run().
+execute format(
+  'select run_id
+     from absurd.%I
+    where task_id = $1
+      and state not in (''completed'', ''failed'', ''cancelled'')
+    order by run_id
+    for update',
+  'r_' || p_queue_name
+        ) using p_task_id;
+
+execute format(
+  'select state
+     from absurd.%I
+    where task_id = $1
+    for update',
+  't_' || p_queue_name
+        )
+  into v_task_state
+  using p_task_id;
+
+if v_task_state is null then
+    raise exception 'Task "%" not found in queue "%"', p_task_id, p_queue_name;
+end if;
+
+  if v_task_state in ('completed', 'failed', 'cancelled') then
+    return;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = ''cancelled'',
+          cancelled_at = coalesce(cancelled_at, $2)
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using p_task_id, v_now;
+
+execute format(
+  'update absurd.%I
+      set state = ''cancelled'',
+          claimed_by = null,
+          claim_expires_at = null
+    where task_id = $1
+      and state not in (''completed'', ''failed'', ''cancelled'')',
+  'r_' || p_queue_name
+        ) using p_task_id;
+
+execute format(
+  'delete from absurd.%I where task_id = $1',
+  'w_' || p_queue_name
+        ) using p_task_id;
+end;
+$$;
+
+-- Cleans up old completed, failed, or cancelled tasks and their related data.
+-- Deletes tasks whose terminal timestamp (completed_at, failed_at, or cancelled_at)
+-- is older than the specified TTL in seconds.
+--
+-- Returns the number of tasks deleted.
+create function absurd.cleanup_tasks (
+  p_queue_name text,
+  p_ttl_seconds integer,
+  p_limit integer default 1000
+)
+  returns integer
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_cutoff timestamptz;
+  v_deleted_count integer;
+begin
+  if p_ttl_seconds is null or p_ttl_seconds < 0 then
+    raise exception 'TTL must be a non-negative number of seconds';
+end if;
+
+  v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
+
+  -- Delete in order: wait registrations, checkpoints, runs, then tasks
+  -- Use a CTE to find eligible tasks and delete their related data
+execute format(
+  'with eligible_tasks as (
+      select t.task_id,
+             case
+               when t.state = ''completed'' then r.completed_at
+               when t.state = ''failed'' then r.failed_at
+               when t.state = ''cancelled'' then t.cancelled_at
+               else null
+             end as terminal_at
+        from absurd.%1$I t
+        left join absurd.%2$I r on r.run_id = t.last_attempt_run
+       where t.state in (''completed'', ''failed'', ''cancelled'')
+   ),
+   to_delete as (
+      select task_id
+        from eligible_tasks
+       where terminal_at is not null
+         and terminal_at < $1
+       order by terminal_at
+       limit $2
+   ),
+   del_waits as (
+      delete from absurd.%3$I w
+       where w.task_id in (select task_id from to_delete)
+   ),
+   del_checkpoints as (
+      delete from absurd.%4$I c
+       where c.task_id in (select task_id from to_delete)
+   ),
+   del_runs as (
+      delete from absurd.%2$I r
+       where r.task_id in (select task_id from to_delete)
+   ),
+   del_tasks as (
+      delete from absurd.%1$I t
+       where t.task_id in (select task_id from to_delete)
+       returning 1
+   )
+   select count(*) from del_tasks',
+  't_' || p_queue_name,
+  'r_' || p_queue_name,
+  'w_' || p_queue_name,
+  'c_' || p_queue_name
+        )
+  into v_deleted_count
+  using v_cutoff, p_limit;
+
+return v_deleted_count;
+end;
+$$;
+
+-- Cleans up old emitted events.
+-- Deletes events whose emitted_at timestamp is older than the specified TTL in seconds.
+--
+-- Returns the number of events deleted.
+create function absurd.cleanup_events (
+  p_queue_name text,
+  p_ttl_seconds integer,
+  p_limit integer default 1000
+)
+  returns integer
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_cutoff timestamptz;
+  v_deleted_count integer;
+begin
+  if p_ttl_seconds is null or p_ttl_seconds < 0 then
+    raise exception 'TTL must be a non-negative number of seconds';
+end if;
+
+  v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
+
+execute format(
+  'with to_delete as (
+      select event_name
+        from absurd.%I
+       where emitted_at < $1
+       order by emitted_at
+       limit $2
+   ),
+   del_events as (
+      delete from absurd.%I e
+       where e.event_name in (select event_name from to_delete)
+       returning 1
+   )
+   select count(*) from del_events',
+  'e_' || p_queue_name,
+  'e_' || p_queue_name
+        )
+  into v_deleted_count
+  using v_cutoff, p_limit;
+
+return v_deleted_count;
+end;
+$$;
+
+-- utility function to generate a uuidv7 even for older postgres versions.
+create function absurd.portable_uuidv7 ()
+  returns uuid
+  language plpgsql
+  volatile
+as $$
+declare
+v_server_num integer := current_setting('server_version_num')::int;
+  ts_ms bigint;
+  b bytea;
+  rnd bytea;
+  i int;
+begin
+  if v_server_num >= 180000 then
+    return uuidv7 ();
+end if;
+  ts_ms := floor(extract(epoch from absurd.current_time()) * 1000)::bigint;
+  rnd := uuid_send(uuid_generate_v4 ());
+  b := repeat(E'\\000', 16)::bytea;
+for i in 0..5 loop
+    b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
+end loop;
+for i in 6..15 loop
+    b := set_byte(b, i, get_byte(rnd, i));
+end loop;
+  b := set_byte(b, 6, ((get_byte(b, 6) & 15) | (7 << 4)));
+  b := set_byte(b, 8, ((get_byte(b, 8) & 63) | 128));
+return encode(b, 'hex')::uuid;
+end;
+$$;

--- a/os/server/db/src/jvmMain/resources/migrations/v3__absurdctrl_create-queue_default.sql
+++ b/os/server/db/src/jvmMain/resources/migrations/v3__absurdctrl_create-queue_default.sql
@@ -1,0 +1,1 @@
+ SELECT absurd.create_queue('default');


### PR DESCRIPTION
Wasmo DB migration: Automatically install absurd and an absurd queue named 'default'

After this commit, Wasmo DB schema version increases to version 3:

 - `v2__absurdctl_init_ref_0.3.0.sql` is an exact copy of
   `support/absurd/vendor/absurd/sql/absurd.sql` (about 50 KBytes),
   corresponding to absurd schema version 0.3.0
 - `v3__absurdctrl_create-queue_default.sql` is manually written based
   on what I think will happens if one runs `absurdctl create-queue default`
   ([source](https://github.com/earendil-works/absurd/blob/0.3.0/absurdctl#L918)).

Tested:
```
$ absurdctl list-queues

default
```