### PR TITLE
Start to provide Distribution entrypoints other than for starting the WasmoOs server

### DIFF
--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabDistribution.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabDistribution.kt
@@ -12,7 +12,7 @@ import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.sql.ProvisioningDb
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.wiring.Distribution
-import com.wasmo.wiring.WasmoService
+import com.wasmo.wiring.DistributionGraph
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -32,17 +32,17 @@ private val sharedPostgresqlAddress = PostgresqlAddress(
   ssl = false,
 )
 
-class HomelabDistribution() : Distribution() {
+internal class HomelabDistribution() : Distribution() {
   override val osPostgresqlAddress: PostgresqlAddress
     get() = sharedPostgresqlAddress
   override val provisioningPostgresqlAddress: PostgresqlAddress
     get() = sharedPostgresqlAddress
 
-  override fun createService(
+  override fun createServiceGraph(
     server: EmbeddedServer<*, *>,
     provisioningDb: ProvisioningDb,
     wasmoDb: SqlDatabase,
-  ): WasmoService {
+  ): DistributionGraph {
     val homelabGraphFactory = createGraphFactory<HomelabGraph.Factory>()
     val serviceGraph = homelabGraphFactory.create(
       server = server,
@@ -68,6 +68,6 @@ class HomelabDistribution() : Distribution() {
       ),
       sessionCookieSpec = SessionCookieSpec.Http,
     )
-    return serviceGraph.wasmoService
+    return serviceGraph
   }
 }

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabDistribution.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabDistribution.kt
@@ -1,0 +1,73 @@
+package com.wasmo.distributions.homelab
+
+import com.wasmo.accounts.CookieSecret
+import com.wasmo.accounts.SessionCookieSpec
+import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.common.catalog.DevelopmentCatalog
+import com.wasmo.identifiers.Deployment
+import com.wasmo.objectstore.FileSystemObjectStoreAddress
+import com.wasmo.sendemail.postmark.PostmarkCredentials
+import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
+import com.wasmo.sql.PostgresqlAddress
+import com.wasmo.sql.ProvisioningDb
+import com.wasmo.stripe.StripeCredentials
+import com.wasmo.wiring.Distribution
+import com.wasmo.wiring.WasmoService
+import dev.zacsweers.metro.createGraphFactory
+import io.ktor.server.engine.EmbeddedServer
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.ByteString.Companion.encodeUtf8
+import okio.Path.Companion.toPath
+import wasmo.sql.SqlDatabase
+
+private val stripePublishableKey = System.getenv("STRIPE_PUBLISHABLE_KEY")
+  ?: error("required env STRIPE_PUBLISHABLE_KEY not set")
+private val stripeSecretKey = System.getenv("STRIPE_SECRET_KEY")
+  ?: error("required env STRIPE_SECRET_KEY not set")
+private val sharedPostgresqlAddress = PostgresqlAddress(
+  user = "postgres",
+  password = "password",
+  hostname = "localhost",
+  databaseName = "wasmo_development",
+  ssl = false,
+)
+
+class HomelabDistribution() : Distribution() {
+  override val osPostgresqlAddress: PostgresqlAddress
+    get() = sharedPostgresqlAddress
+  override val provisioningPostgresqlAddress: PostgresqlAddress
+    get() = sharedPostgresqlAddress
+
+  override fun createService(
+    server: EmbeddedServer<*, *>,
+    provisioningDb: ProvisioningDb,
+    wasmoDb: SqlDatabase,
+  ): WasmoService {
+    val homelabGraphFactory = createGraphFactory<HomelabGraph.Factory>()
+    val serviceGraph = homelabGraphFactory.create(
+      server = server,
+      cookieSecret = CookieSecret("butters".encodeUtf8()),
+      postmarkCredentials = PostmarkCredentials(
+        baseUrl = PostmarkProductionBaseUrl,
+        serverToken = System.getenv("POSTMARK_SERVER_TOKEN") ?: "?",
+      ),
+      stripeCredentials = StripeCredentials(
+        publishableKey = StripePublishableKey(stripePublishableKey),
+        secretKey = stripeSecretKey,
+      ),
+      catalog = DevelopmentCatalog,
+      wasmoDb = wasmoDb,
+      provisioningDb = provisioningDb,
+      postgresqlAddress = sharedPostgresqlAddress,
+      deployment = Deployment(
+        baseUrl = "http://wasmo.localhost:8080/".toHttpUrl(),
+        sendFromEmailAddress = "noreply@wasmo.dev",
+      ),
+      objectStoreAddress = FileSystemObjectStoreAddress(
+        path = System.getProperty("user.home").toPath() / ".wasmo",
+      ),
+      sessionCookieSpec = SessionCookieSpec.Http,
+    )
+    return serviceGraph.wasmoService
+  }
+}

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
@@ -4,10 +4,8 @@ import com.wasmo.accounts.AccountsBindings
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
 import com.wasmo.accounts.passkeys.AccountsPasskeysBindings
-import com.wasmo.api.routes.RouteCodec
 import com.wasmo.calls.CallGraph
 import com.wasmo.common.catalog.Catalog
-import com.wasmo.common.routes.RealRouteCodec
 import com.wasmo.computers.ComputerServiceGraph
 import com.wasmo.computers.ComputersBindings
 import com.wasmo.db.Migrator
@@ -31,9 +29,9 @@ import com.wasmo.sql.SqlServiceBindings
 import com.wasmo.stripe.StripeBindings
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.website.WebsiteBindings
+import com.wasmo.wiring.DistributionGraph
 import com.wasmo.wiring.ObjectStoreBindings
 import com.wasmo.wiring.ServiceBindings
-import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -62,8 +60,8 @@ import wasmo.sql.SqlDatabase
     WebsiteBindings::class,
   ],
 )
-internal interface HomelabGraph {
-  val wasmoService: WasmoService
+
+internal interface HomelabGraph : DistributionGraph {
   val callGraphFactory: CallGraph.Factory
   val computerServiceGraphFactory: ComputerServiceGraph.Factory
   val installedAppServiceGraphFactory: InstalledAppServiceGraph.Factory

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabPrestartWasmoServiceAndExit.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabPrestartWasmoServiceAndExit.kt
@@ -1,0 +1,8 @@
+package com.wasmo.distributions.homelab
+
+import kotlinx.coroutines.runBlocking
+
+fun main(args: Array<String>): Unit = runBlocking {
+  val homelabDistribution = HomelabDistribution()
+  homelabDistribution.prestartWasmoServiceAndExit(args)
+}

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
@@ -3,80 +3,12 @@
 
 package com.wasmo.distributions.homelab
 
-import com.wasmo.accounts.CookieSecret
-import com.wasmo.accounts.SessionCookieSpec
-import com.wasmo.api.stripe.StripePublishableKey
-import com.wasmo.common.catalog.DevelopmentCatalog
-import com.wasmo.identifiers.Deployment
-import com.wasmo.objectstore.FileSystemObjectStoreAddress
-import com.wasmo.sendemail.postmark.PostmarkCredentials
-import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
-import com.wasmo.sql.PostgresqlAddress
-import com.wasmo.sql.ProvisioningDb
-import com.wasmo.stripe.StripeCredentials
-import com.wasmo.wiring.Distribution
-import com.wasmo.wiring.WasmoService
-import dev.zacsweers.metro.createGraphFactory
-import io.ktor.server.engine.EmbeddedServer
-import kotlin.Unit
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import okio.ByteString.Companion.encodeUtf8
-import okio.Path.Companion.toPath
-import wasmo.sql.SqlDatabase
 
+/**
+ * Entrypoint for running Homelab Wasmo server.
+ */
 fun main(args: Array<String>): Unit = runBlocking {
-  val stripePublishableKey = System.getenv("STRIPE_PUBLISHABLE_KEY")
-    ?: error("required env STRIPE_PUBLISHABLE_KEY not set")
-  val stripeSecretKey = System.getenv("STRIPE_SECRET_KEY")
-    ?: error("required env STRIPE_SECRET_KEY not set")
-  val sharedPostgresqlAddress = PostgresqlAddress(
-    user = "postgres",
-    password = "password",
-    hostname = "localhost",
-    databaseName = "wasmo_development",
-    ssl = false,
-  )
-
-  val homelabDistribution = object : Distribution() {
-    override val osPostgresqlAddress: PostgresqlAddress
-      get() = sharedPostgresqlAddress
-    override val provisioningPostgresqlAddress: PostgresqlAddress
-      get() = sharedPostgresqlAddress
-
-    override fun createService(
-      server: EmbeddedServer<*, *>,
-      provisioningDb: ProvisioningDb,
-      wasmoDb: SqlDatabase,
-    ): WasmoService {
-      val homelabGraphFactory = createGraphFactory<HomelabGraph.Factory>()
-      val serviceGraph = homelabGraphFactory.create(
-        server = server,
-        cookieSecret = CookieSecret("butters".encodeUtf8()),
-        postmarkCredentials = PostmarkCredentials(
-          baseUrl = PostmarkProductionBaseUrl,
-          serverToken = System.getenv("POSTMARK_SERVER_TOKEN") ?: "?",
-        ),
-        stripeCredentials = StripeCredentials(
-          publishableKey = StripePublishableKey(stripePublishableKey),
-          secretKey = stripeSecretKey,
-        ),
-        catalog = DevelopmentCatalog,
-        wasmoDb = wasmoDb,
-        provisioningDb = provisioningDb,
-        postgresqlAddress = sharedPostgresqlAddress,
-        deployment = Deployment(
-          baseUrl = "http://wasmo.localhost:8080/".toHttpUrl(),
-          sendFromEmailAddress = "noreply@wasmo.dev",
-        ),
-        objectStoreAddress = FileSystemObjectStoreAddress(
-          path = System.getProperty("user.home").toPath() / ".wasmo",
-        ),
-        sessionCookieSpec = SessionCookieSpec.Http,
-      )
-      return serviceGraph.wasmoService
-    }
-  }
-
+  val homelabDistribution = HomelabDistribution()
   homelabDistribution.start(args)
 }

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabWasmoOs.kt
@@ -10,5 +10,5 @@ import kotlinx.coroutines.runBlocking
  */
 fun main(args: Array<String>): Unit = runBlocking {
   val homelabDistribution = HomelabDistribution()
-  homelabDistribution.start(args)
+  homelabDistribution.startWasmoService(args)
 }

--- a/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedGraph.kt
+++ b/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedGraph.kt
@@ -30,6 +30,7 @@ import com.wasmo.sql.SqlServiceBindings
 import com.wasmo.stripe.StripeBindings
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.website.WebsiteBindings
+import com.wasmo.wiring.DistributionGraph
 import com.wasmo.wiring.ObjectStoreBindings
 import com.wasmo.wiring.ServiceBindings
 import com.wasmo.wiring.WasmoService
@@ -61,8 +62,7 @@ import wasmo.sql.SqlDatabase
     WebsiteBindings::class,
   ],
 )
-internal interface HostedGraph {
-  val wasmoService: WasmoService
+internal interface HostedGraph : DistributionGraph {
   val callGraphFactory: CallGraph.Factory
   val computerServiceGraphFactory: ComputerServiceGraph.Factory
   val installedAppServiceGraphFactory: InstalledAppServiceGraph.Factory

--- a/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedWasmoOs.kt
+++ b/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedWasmoOs.kt
@@ -15,6 +15,7 @@ import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.sql.ProvisioningDb
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.wiring.Distribution
+import com.wasmo.wiring.DistributionGraph
 import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
@@ -61,11 +62,11 @@ fun main(args: Array<String>): Unit = runBlocking {
     override val provisioningPostgresqlAddress: PostgresqlAddress
       get() = sharedPostgresqlAddress
 
-    override fun createService(
+    override fun createServiceGraph(
       server: EmbeddedServer<*, *>,
       provisioningDb: ProvisioningDb,
       wasmoDb: SqlDatabase,
-    ): WasmoService {
+    ): DistributionGraph {
       val hostedGraphFactory = createGraphFactory<HostedGraph.Factory>()
       val serviceGraph = hostedGraphFactory.create(
         server = server,
@@ -94,9 +95,7 @@ fun main(args: Array<String>): Unit = runBlocking {
         ),
         sessionCookieSpec = SessionCookieSpec.Https,
       )
-      return serviceGraph.wasmoService
+      return serviceGraph
     }
   }
-
-  hostedDistribution.start(args)
 }

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxGraph.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxGraph.kt
@@ -63,8 +63,7 @@ import wasmo.sql.SqlDatabase
     WebsiteBindings::class,
   ],
 )
-internal interface SandboxGraph {
-  val wasmoService: WasmoService
+internal interface SandboxGraph : DistributionGraph {
   val callGraphFactory: CallGraph.Factory
   val computerServiceGraphFactory: ComputerServiceGraph.Factory
   val installedAppServiceGraphFactory: InstalledAppServiceGraph.Factory

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
@@ -16,7 +16,6 @@ import com.wasmo.sql.ProvisioningDb
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.wiring.Distribution
 import com.wasmo.wiring.DistributionGraph
-import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
 import kotlinx.coroutines.runBlocking
@@ -99,5 +98,5 @@ fun main(args: Array<String>): Unit = runBlocking {
     }
   }
 
-  sandboxDistribution.start(args)
+  sandboxDistribution.startWasmoService(args)
 }

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxWasmoOs.kt
@@ -15,6 +15,7 @@ import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.sql.ProvisioningDb
 import com.wasmo.stripe.StripeCredentials
 import com.wasmo.wiring.Distribution
+import com.wasmo.wiring.DistributionGraph
 import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
@@ -61,11 +62,11 @@ fun main(args: Array<String>): Unit = runBlocking {
     override val provisioningPostgresqlAddress: PostgresqlAddress
       get() = sharedPostgresqlAddress
 
-    override fun createService(
+    override fun createServiceGraph(
       server: EmbeddedServer<*, *>,
       provisioningDb: ProvisioningDb,
       wasmoDb: SqlDatabase,
-    ): WasmoService {
+    ): DistributionGraph {
       val sandboxGraphFactory = createGraphFactory<SandboxGraph.Factory>()
       val serviceGraph = sandboxGraphFactory.create(
         server = server,
@@ -94,7 +95,7 @@ fun main(args: Array<String>): Unit = runBlocking {
         ),
         sessionCookieSpec = SessionCookieSpec.Https,
       )
-      return serviceGraph.wasmoService
+      return serviceGraph
     }
   }
 

--- a/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
+++ b/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
@@ -28,7 +28,7 @@ abstract class Distribution {
     wasmoDb: SqlDatabase,
   ): DistributionGraph
 
-  suspend fun start(args: Array<String>) {
+  suspend fun startWasmoService(args: Array<String>) {
     val server = EngineMain.createServer(args)
 
     val postgresqlClientFactory = PostgresqlClient.Factory()

--- a/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
+++ b/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
@@ -1,5 +1,6 @@
 package com.wasmo.wiring
 
+import com.wasmo.db.Migrator
 import com.wasmo.sql.PostgresqlAddress
 import com.wasmo.sql.PostgresqlClient
 import com.wasmo.sql.ProvisioningDb
@@ -7,6 +8,12 @@ import com.wasmo.sql.asSqlDatabase
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.netty.EngineMain
 import wasmo.sql.SqlDatabase
+import wasmox.sql.transaction
+
+interface DistributionGraph {
+  val wasmoService: WasmoService
+  val migrator: Migrator
+}
 
 /**
  * Each subclass is its own particular distribution of Wasmo OS.
@@ -15,11 +22,11 @@ abstract class Distribution {
   protected abstract val osPostgresqlAddress: PostgresqlAddress
   protected abstract val provisioningPostgresqlAddress: PostgresqlAddress
 
-  protected abstract fun createService(
+  protected abstract fun createServiceGraph(
     server: EmbeddedServer<*, *>,
     provisioningDb: ProvisioningDb,
     wasmoDb: SqlDatabase,
-  ): WasmoService
+  ): DistributionGraph
 
   suspend fun start(args: Array<String>) {
     val server = EngineMain.createServer(args)
@@ -32,12 +39,14 @@ abstract class Distribution {
         .asSqlDatabase(),
     )
     val wasmoDb = osPostgresqlClient.asSqlDatabase()
-    val wasmoService = createService(
+    val serviceGraph = createServiceGraph(
       server = server,
       provisioningDb = provisioningDb,
       wasmoDb = wasmoDb,
     )
-
-    wasmoService.start()
+    wasmoDb.transaction {
+      serviceGraph.migrator.ensureSchemaVersion()
+    }
+    serviceGraph.wasmoService.start()
   }
 }

--- a/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
+++ b/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/Distribution.kt
@@ -28,7 +28,11 @@ abstract class Distribution {
     wasmoDb: SqlDatabase,
   ): DistributionGraph
 
-  suspend fun startWasmoService(args: Array<String>) {
+  interface WasmoServiceControl : AutoCloseable {
+    suspend fun start()
+  }
+
+  private suspend fun commonInit(args: Array<String>): WasmoServiceControl {
     val server = EngineMain.createServer(args)
 
     val postgresqlClientFactory = PostgresqlClient.Factory()
@@ -47,6 +51,28 @@ abstract class Distribution {
     wasmoDb.transaction {
       serviceGraph.migrator.ensureSchemaVersion()
     }
-    serviceGraph.wasmoService.start()
+    return object : WasmoServiceControl {
+      override suspend fun start() {
+        serviceGraph.wasmoService.start()
+      }
+
+      override fun close() {
+        wasmoDb.close()
+        provisioningDb.provisioningDb.close()
+        osPostgresqlClient.close()
+      }
+    }
+  }
+
+  suspend fun startWasmoService(args: Array<String>) {
+    val wasmoServiceStarter = commonInit(args)
+    // start, never close()
+    wasmoServiceStarter.start()
+  }
+
+  suspend fun prestartWasmoServiceAndExit(args: Array<String>) {
+    commonInit(args).use {
+      // nothing
+    } // close() without having started
   }
 }

--- a/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/WasmoService.kt
+++ b/os/server/wiring/src/jvmMain/kotlin/com/wasmo/wiring/WasmoService.kt
@@ -18,14 +18,8 @@ class WasmoService(
   private val server: EmbeddedServer<*, *>,
   private val actionRouter: ActionRouter,
   private val jobProcessor: JobProcessor,
-  private val migrator: Migrator,
-  private val wasmoDb: SqlDatabase,
 ) {
   suspend fun start() {
-    // AbsurdOsJobProcessor from jobProcessor.start() depends on this already having run.
-    wasmoDb.transaction {
-      migrator.ensureSchemaVersion()
-    }
     actionRouter.createRoutes()
     jobProcessor.start()
 


### PR DESCRIPTION
This PR consists of multiple commits, I suggest you review them as individual steps.

Historically, each Distribution only does one thing (start WasmoService); entrypoint and DI graph are purely in service of that one purpose.

This PR proposes that additional entrypoints/tools that share most of the DI graph could be useful. The proof of concept is an entrypoint that exits just short of starting the WasmoService, but after having done the DB migration. This allows us to squash the DB migration steps (including absurd) into a single one, as follows:

 1. Drop and recreate the database (`psql` commands)
 2. run  `Distribution.prestartWasmoServiceAndExit()`
 3. Dump the database (`pgdump`).

**Jesse**: I know you didn't like additional purposes of the Graph but I kind of do. I'm curious what you think after this PR.

----

How:

To separate `WasmoService.start()` from pre-start activities,
 - DB Migration moves out of WasmoServer into Distribution
 - `Distribution.createService()` -> `createServiceGraph`. which requires the *Graph interfaces to derive from a parent interface `DistributionGraph`
 - `Migrator` moves up into `DistributionGraph` to become a sibling of `wasmoService`.

The new `HomelabPrestartWasmoServiceAndExit`:
 -  exposes `Distribution.prestartWasmoServiceAndExit()` as an entrypoint (`main` method) on Homelab. I see no reason not to do the same on Hosted and Sandbox.
 - Reuses `HomelabDistribution`, which moved from `HomelabWasmoOs.kt` into its own .kt file.

Future steps (copied from the last commit's message):
   1. Figure out how to expose HomelabPrestartWasmoServiceAndExit as a Gradle task.
   2. Drop the dependency from Distribution.commonInit() onto EngineMain.createServer(), because in commonInit we don't know yet if the server will actually be started. The complication is that server is then not available to be passed into createServiceGraph(), and there are at least two DI bindings that currently build onto server:
       - KtorLogger constructs `log = server.application.log`
       - ServiceBindings.provideApplication() constructs `application = server.application`
       - If we can construct DI bindings for both without going via server, it should be possible to pull server out of the DistributionGraph (construct it manually, or construct a separate graph for the server-specific parts of the system).
