### PR TITLE
Fix ServiceTester.

### DIFF
--- a/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTester.kt
+++ b/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTester.kt
@@ -3,7 +3,6 @@ package com.wasmo.testing.service
 import app.cash.burst.coroutines.CoroutineTestFunction
 import app.cash.burst.coroutines.CoroutineTestInterceptor
 import com.wasmo.accounts.ClientAuthenticator
-import com.wasmo.db.ensureSchemaVersion
 import com.wasmo.jobs.OsJobQueue
 import com.wasmo.passkeys.RealAuthenticatorDatabase
 import com.wasmo.permits.PermitService
@@ -123,10 +122,6 @@ class ServiceTester : CoroutineTestInterceptor {
         provisioningDb = wasmoDb,
       )
 
-      wasmoDb.withConnection {
-        ensureSchemaVersion()
-      }
-
       intercept(
         wasmoDb = wasmoDb,
         provisioningDb = provisioningDb,
@@ -159,6 +154,9 @@ class ServiceTester : CoroutineTestInterceptor {
             fileSystem = fileSystem,
             testDirectory = testDirectory,
           )
+          wasmoDb.withConnection {
+            graph.migrator.ensureSchemaVersion()
+          }
           graph.absurdService.createQueue()
 
           testFunction()

--- a/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTesterGraph.kt
+++ b/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTesterGraph.kt
@@ -4,6 +4,8 @@ import com.wasmo.accounts.AccountsBindings
 import com.wasmo.accounts.ClientAuthenticator
 import com.wasmo.computers.ComputerServiceGraph
 import com.wasmo.computers.ComputersBindings
+import com.wasmo.db.Migrator
+import com.wasmo.db.RealMigrator
 import com.wasmo.identifiers.Deployment
 import com.wasmo.identifiers.OsScope
 import com.wasmo.installedapps.InstalledAppBindings
@@ -24,6 +26,7 @@ import com.wasmo.testing.apps.SampleApps
 import com.wasmo.testing.call.CallTesterGraph
 import com.wasmo.testing.client.ClientTester
 import com.wasmo.testing.events.TestEventListener
+import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +63,7 @@ interface ServiceTesterGraph {
   val fakeHttpClient: FakeHttpService
   val fileSystem: FileSystem
   val permitService: PermitService
+  val migrator: Migrator
 
   @TestDirectory
   val testDirectory: Path
@@ -71,6 +75,9 @@ interface ServiceTesterGraph {
   val sampleApps: SampleApps
   val absurdService: AbsurdService
   val jobQueueFactory: OsJobQueue.Factory
+
+  @Binds
+  fun bindMigrator(real: RealMigrator): Migrator
 
   @DependencyGraph.Factory
   interface Factory {


### PR DESCRIPTION
Since commit 0426e9528509f32ef21acfbc5d52a7a37a6540e7, ensureSchemaVersion() is inside Migrator.

I arbitrarily bound Migrator to RealMigrator (as opposed to RealHomelabMigrator or something else) in ServiceTester's graph. Can be reconsidered in future.