### PR TITLE
start refactoring SignedIn state out of AccountSnapshot

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
@@ -9,13 +9,21 @@ import okio.ByteString
 @Serializable
 data class AccountSnapshot(
   val nextChallenge: @Serializable(Base64UrlSerializer::class) ByteString,
-  val passkeys: List<PasskeySnapshot>,
-  val emailAddresses: List<LinkedEmailAddressSnapshot>,
+  private val passkeys: List<PasskeySnapshot>,
+  private val emailAddresses: List<LinkedEmailAddressSnapshot>,
   val hasInvite: Boolean,
 ) {
+  // TODO: make signedInSnapshot a ctor argument (changes wire format), and support
+  // Username-based SignedInSnapshot server-side.
+  val signedInSnapshot: SignedInSnapshot? =
+    // TODO: We probably want "passkeys.isEmpty() &&", but that'll be a behavior change to before
+    if (emailAddresses.isEmpty()) {
+      null
+    } else {
+      EmailPasskeySignedInSnapshot(passkeys, emailAddresses)
+    }
   val isSignedIn: Boolean
-    // TODO: Do we also need "passkeys.isNotEmpty() ||" ?
-    get() = emailAddresses.isNotEmpty()
+    get() = signedInSnapshot != null
 }
 
 @Serializable

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
@@ -12,7 +12,11 @@ data class AccountSnapshot(
   val passkeys: List<PasskeySnapshot>,
   val emailAddresses: List<LinkedEmailAddressSnapshot>,
   val hasInvite: Boolean,
-)
+) {
+  val isSignedIn: Boolean
+    // TODO: Do we also need "passkeys.isNotEmpty() ||" ?
+    get() = emailAddresses.isNotEmpty()
+}
 
 @Serializable
 data object AccountSnapshotRequest

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/SignedInSnapshot.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/SignedInSnapshot.kt
@@ -1,0 +1,24 @@
+package com.wasmo.api
+
+import com.wasmo.identifiers.UsernameSlug
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class SignedInSnapshot
+
+@Serializable
+class EmailPasskeySignedInSnapshot(
+  val passkeys: List<PasskeySnapshot>,
+  val emailAddresses: List<LinkedEmailAddressSnapshot>,
+) : SignedInSnapshot() {
+  init {
+    require(passkeys.isNotEmpty() || emailAddresses.isNotEmpty()) {
+      "At least one passkey or email address required to be signed in."
+    }
+  }
+}
+
+@Serializable
+class UsernameSignedInSnapshot(
+  val username: UsernameSlug,
+) : SignedInSnapshot()

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
@@ -42,7 +42,7 @@ class HomeUi(
     val accountSnapshot by accountDataService.accountSnapshotFlow.collectAsState()
     val menuModel = HomeMenuModel(
       visible = menuVisible,
-      signedIn = accountSnapshot.emailAddresses.isNotEmpty(),
+      signedIn = accountSnapshot.isSignedIn,
     )
 
     HomeScreen(
@@ -55,7 +55,7 @@ class HomeUi(
           iframeSrc = routeCodec.encode(ComputerHomeRoute(it.slug)).toURL().href,
         )
       },
-      showNewComputer = environment.showSignUp && accountSnapshot.emailAddresses.isNotEmpty(),
+      showNewComputer = environment.showSignUp && accountSnapshot.isSignedIn,
     )
   }
 

--- a/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/LinkEmailAddressTest.kt
+++ b/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/LinkEmailAddressTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.wasmo.api.ConfirmEmailAddressResponse.Decision
+import com.wasmo.api.EmailPasskeySignedInSnapshot
 import com.wasmo.api.LinkedEmailAddressSnapshot
 import com.wasmo.testing.emails.differentCode
 import com.wasmo.testing.emails.extractChallengeCode
@@ -36,7 +37,7 @@ class LinkEmailAddressTest {
       challengeCode = email.extractChallengeCode(),
     )
     assertThat(confirmResponse.body.decision).isEqualTo(Decision.LinkedNew)
-    assertThat(confirmResponse.body.account?.emailAddresses)
+    assertThat((confirmResponse.body.account?.signedInSnapshot as? EmailPasskeySignedInSnapshot)?.emailAddresses)
       .isNotNull()
       .containsExactly(
         LinkedEmailAddressSnapshot(
@@ -54,7 +55,7 @@ class LinkEmailAddressTest {
     assertThat(confirmResponse1.body.decision).isEqualTo(Decision.LinkedNew)
     val confirmResponse2 = client.linkAndConfirmEmailAddress("jessewilson@example.com")
     assertThat(confirmResponse2.body.decision).isEqualTo(Decision.LinkedNew)
-    assertThat(confirmResponse2.body.account?.emailAddresses)
+    assertThat((confirmResponse2.body.account?.signedInSnapshot as? EmailPasskeySignedInSnapshot)?.emailAddresses)
       .isNotNull()
       .containsExactly(
         LinkedEmailAddressSnapshot(
@@ -88,7 +89,7 @@ class LinkEmailAddressTest {
       challengeCode = email.extractChallengeCode(),
     )
     assertThat(confirmResponse.body.decision).isEqualTo(Decision.LinkedExisting)
-    assertThat(confirmResponse.body.account?.emailAddresses)
+    assertThat((confirmResponse.body.account?.signedInSnapshot as? EmailPasskeySignedInSnapshot)?.emailAddresses)
       .isNotNull()
       .containsExactly(
         LinkedEmailAddressSnapshot(

--- a/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/SignInSignOutTest.kt
+++ b/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/SignInSignOutTest.kt
@@ -4,6 +4,7 @@ import app.cash.burst.InterceptTest
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import com.wasmo.api.SignOutRequest
 import com.wasmo.api.SignOutResponse
@@ -21,15 +22,19 @@ class SignInSignOutTest {
 
     val confirmResponse = client.linkAndConfirmEmailAddress("jesse@example.com")
     assertThat(confirmResponse.body.account?.isSignedIn)
+      .isNotNull()
+      .isTrue()
 
     val accountSnapshotResponse1 = client.accountSnapshot()
     assertThat(accountSnapshotResponse1.isSignedIn)
+      .isTrue()
 
     val signOutResponse = client.call().signOut(SignOutRequest)
     assertThat(signOutResponse.body).isEqualTo(SignOutResponse)
 
     val accountSnapshotResponse2 = client.accountSnapshot()
-    assertThat(!accountSnapshotResponse2.isSignedIn)
+    assertThat(accountSnapshotResponse2.isSignedIn)
+      .isFalse()
   }
 
   @Test
@@ -38,16 +43,20 @@ class SignInSignOutTest {
 
     val confirmResponse = client.linkAndConfirmEmailAddress("jesse@example.com")
     assertThat(confirmResponse.body.account?.isSignedIn)
+      .isNotNull()
+      .isTrue()
 
     val accountSnapshotResponse1 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse1.isSignedIn).isTrue()
+    assertThat(accountSnapshotResponse1.isSignedIn)
+      .isTrue()
 
     val signOutResponse = client.call().signOutPage()
     assertThat(signOutResponse.header("Location"))
       .isEqualTo("https://wasmo.com/")
 
     val accountSnapshotResponse2 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse2.isSignedIn).isFalse()
+    assertThat(accountSnapshotResponse2.isSignedIn)
+      .isFalse()
   }
 
   @Test
@@ -61,12 +70,14 @@ class SignInSignOutTest {
     client2.linkAndConfirmEmailAddress("jesse@example.com")
 
     val accountSnapshotResponse1 = client2.accountSnapshot()
-    assertThat(accountSnapshotResponse1.isSignedIn).isTrue()
+    assertThat(accountSnapshotResponse1.isSignedIn)
+      .isTrue()
 
     val signOutResponse = client2.call().signOut(SignOutRequest)
     assertThat(signOutResponse.body).isEqualTo(SignOutResponse)
 
     val accountSnapshotResponse2 = client2.accountSnapshot()
-    assertThat(accountSnapshotResponse2.isSignedIn).isFalse()
+    assertThat(accountSnapshotResponse2.isSignedIn)
+      .isFalse()
   }
 }

--- a/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/SignInSignOutTest.kt
+++ b/os/server/emails/real/src/jvmTest/kotlin/com/wasmo/emails/SignInSignOutTest.kt
@@ -2,10 +2,9 @@ package com.wasmo.emails
 
 import app.cash.burst.InterceptTest
 import assertk.assertThat
-import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
-import assertk.assertions.isNotNull
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import com.wasmo.api.SignOutRequest
 import com.wasmo.api.SignOutResponse
 import com.wasmo.testing.service.ServiceTester
@@ -21,22 +20,16 @@ class SignInSignOutTest {
     val client = tester.newClient()
 
     val confirmResponse = client.linkAndConfirmEmailAddress("jesse@example.com")
-    assertThat(confirmResponse.body.account?.emailAddresses)
-      .isNotNull()
-      .isNotEmpty()
+    assertThat(confirmResponse.body.account?.isSignedIn)
 
     val accountSnapshotResponse1 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse1.emailAddresses)
-      .isNotNull()
-      .isNotEmpty()
+    assertThat(accountSnapshotResponse1.isSignedIn)
 
     val signOutResponse = client.call().signOut(SignOutRequest)
     assertThat(signOutResponse.body).isEqualTo(SignOutResponse)
 
     val accountSnapshotResponse2 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse2.emailAddresses)
-      .isNotNull()
-      .isEmpty()
+    assertThat(!accountSnapshotResponse2.isSignedIn)
   }
 
   @Test
@@ -44,23 +37,17 @@ class SignInSignOutTest {
     val client = tester.newClient()
 
     val confirmResponse = client.linkAndConfirmEmailAddress("jesse@example.com")
-    assertThat(confirmResponse.body.account?.emailAddresses)
-      .isNotNull()
-      .isNotEmpty()
+    assertThat(confirmResponse.body.account?.isSignedIn)
 
     val accountSnapshotResponse1 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse1.emailAddresses)
-      .isNotNull()
-      .isNotEmpty()
+    assertThat(accountSnapshotResponse1.isSignedIn).isTrue()
 
     val signOutResponse = client.call().signOutPage()
     assertThat(signOutResponse.header("Location"))
       .isEqualTo("https://wasmo.com/")
 
     val accountSnapshotResponse2 = client.accountSnapshot()
-    assertThat(accountSnapshotResponse2.emailAddresses)
-      .isNotNull()
-      .isEmpty()
+    assertThat(accountSnapshotResponse2.isSignedIn).isFalse()
   }
 
   @Test
@@ -74,16 +61,12 @@ class SignInSignOutTest {
     client2.linkAndConfirmEmailAddress("jesse@example.com")
 
     val accountSnapshotResponse1 = client2.accountSnapshot()
-    assertThat(accountSnapshotResponse1.emailAddresses)
-      .isNotNull()
-      .isNotEmpty()
+    assertThat(accountSnapshotResponse1.isSignedIn).isTrue()
 
     val signOutResponse = client2.call().signOut(SignOutRequest)
     assertThat(signOutResponse.body).isEqualTo(SignOutResponse)
 
     val accountSnapshotResponse2 = client2.accountSnapshot()
-    assertThat(accountSnapshotResponse2.emailAddresses)
-      .isNotNull()
-      .isEmpty()
+    assertThat(accountSnapshotResponse2.isSignedIn).isFalse()
   }
 }


### PR DESCRIPTION
First steps towards implementing [docs/code/accounts_and_authentication.md](https://github.com/wasmcomputercompany/wasmo/blob/8db5af7f3b821b4114aed7eeb914b7d310cea0cd/docs/code/accounts_and_authentication.md): signed-in status can be conferred by username [/password], not necessarily email addresses / passkeys.

- HomeUi only depends on `isSignedIn`
- Some tests depend on specifics
  - Factored out sealed `SignedInSnapshot` with implementations `EmailPasskeySignedInSnapshot` and `UsernameSignedInSnapshot` (unused)
  - Construction currently still happens inside `AccountSnapshot`; next step will be to construct server-side and change the `AccountSnapshot` wire format.

This PR consists of separate commits, in case you prefer to review them individually.