### PR TITLE
Introduce accountSnapshot.isSignedIn and determine it server-side.

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
@@ -12,6 +12,7 @@ data class AccountSnapshot(
   val passkeys: List<PasskeySnapshot>,
   val emailAddresses: List<LinkedEmailAddressSnapshot>,
   val hasInvite: Boolean,
+  val isSignedIn: Boolean,
 )
 
 @Serializable

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
@@ -42,7 +42,7 @@ class HomeUi(
     val accountSnapshot by accountDataService.accountSnapshotFlow.collectAsState()
     val menuModel = HomeMenuModel(
       visible = menuVisible,
-      signedIn = accountSnapshot.emailAddresses.isNotEmpty(),
+      signedIn = accountSnapshot.isSignedIn,
     )
 
     HomeScreen(
@@ -55,7 +55,7 @@ class HomeUi(
           iframeSrc = routeCodec.encode(ComputerHomeRoute(it.slug)).toURL().href,
         )
       },
-      showNewComputer = environment.showSignUp && accountSnapshot.emailAddresses.isNotEmpty(),
+      showNewComputer = environment.showSignUp && accountSnapshot.isSignedIn,
     )
   }
 

--- a/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
+++ b/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
@@ -103,11 +103,14 @@ class RealCallDataService(
     override suspend fun load(): AccountSnapshot {
       val firstInvite = firstClaimedInvite.get()
 
+      val emailAddresses = linkedEmailAddresses.get()
       return AccountSnapshot(
         nextChallenge = client.challenger.create(),
         passkeys = passkeys.get(),
-        emailAddresses = linkedEmailAddresses.get(),
+        emailAddresses = emailAddresses,
         hasInvite = firstInvite != null,
+        // TODO: isSignedIn should also reflect other ways of being signed in.
+        isSignedIn = emailAddresses.isNotEmpty(),
       )
     }
   }


### PR DESCRIPTION
HomeUi now uses this instead of accountSnapshot.emailAddresses.isNotEmpty().

This is prep for supporting other ways of being signed-in.

This PR replaces https://github.com/wasmcomputercompany/wasmo/pull/34, which I have closed.