### PR TITLE
Username sign-in step: Introduce and partially wire-up SignInSnapshot.

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/OsHtml.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/OsHtml.kt
@@ -10,4 +10,5 @@ interface OsHtml {
   val inviteTicket: InviteTicket?
   val computerSnapshot: ComputerSnapshot?
   val computerListSnapshot: ComputerListSnapshot?
+  val signInSnapshot: SignInSnapshot?
 }

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/Username.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/Username.kt
@@ -25,3 +25,9 @@ data class LinkedUsernameSnapshot(
   val linkedAt: Instant,
   val username: UsernameSlug,
 )
+
+@Serializable
+data class SignInSnapshot(
+  val usernameOptions: List<UsernameSlug> = listOf(),
+  val canCreateUsername: Boolean = false,
+)

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/routes/Routes.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/routes/Routes.kt
@@ -23,6 +23,8 @@ data class InviteRoute(
 
 data object AdminRoute : Route
 
+data object SignInRoute: Route
+
 data object SignOutRoute : Route
 
 data object SignUpRoute : Route

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/WasmoWebAppGraph.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/WasmoWebAppGraph.kt
@@ -3,6 +3,7 @@ package com.wasmo.client.app
 import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.ComputerSnapshot
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.WasmoApi
 import com.wasmo.api.routes.RouteCodec
 import com.wasmo.api.routes.RoutingContext
@@ -75,6 +76,11 @@ interface WasmoWebAppGraph {
   @SingleIn(ClientAppScope::class)
   fun provideComputerListSnapshot(pageData: PageData): ComputerListSnapshot? =
     pageData.get<ComputerListSnapshot>("computer_list_snapshot")
+
+  @Provides
+  @SingleIn(ClientAppScope::class)
+  fun provideSignInSnapshot(pageData: PageData): SignInSnapshot? =
+    pageData.get<SignInSnapshot>("sign_in_snapshot")
 
   @Provides
   @SingleIn(ClientAppScope::class)

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
@@ -9,6 +9,7 @@ import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.routes.BuildYoursRoute
 import com.wasmo.api.routes.ComputerHomeRoute
 import com.wasmo.api.routes.RouteCodec
+import com.wasmo.api.routes.SignInRoute
 import com.wasmo.api.routes.SignOutRoute
 import com.wasmo.api.routes.SignUpRoute
 import com.wasmo.client.app.Environment
@@ -75,7 +76,7 @@ class HomeUi(
 
       HomeEvent.ClickSignIn -> {
         menuVisible = false
-        router.goTo(SignUpRoute, TransitionDirection.PUSH)
+        router.goTo(SignInRoute, TransitionDirection.PUSH)
       }
 
       HomeEvent.ClickSignUp -> {

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
@@ -1,6 +1,7 @@
 package com.wasmo.client.app.signup
 
 import com.wasmo.api.ConfirmEmailAddressResponse.Decision
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.routes.HomeRoute
 import com.wasmo.client.app.data.AccountDataService
 import com.wasmo.client.app.routing.Router
@@ -22,13 +23,25 @@ class SignUpPresenter(
   private val scope: CoroutineScope,
   private val router: Router,
   private val accountDataService: AccountDataService,
+  signInSnapshot: SignInSnapshot?,
 ) : Presenter<SignUpModel, SignUpEvent> {
   private val mutableModel = MutableStateFlow(
-    SignUpModel(
-      enterEmailAddress = EnterEmailAddressModel(
-        emailAddressHelperText = "We’ll email you a challenge code",
-      ),
-    ),
+    // TODO: Make SignInSnapshot responsible for all sign-in options, not only username.
+    if (signInSnapshot == null) {
+      SignUpModel(
+        enterEmailAddress = EnterEmailAddressModel(
+          emailAddressHelperText = "We’ll email you a challenge code",
+        )
+      )
+    } else {
+      SignUpModel(
+        selectUsernameToSignIn = SelectUsernameToSignInModel(
+          usernameOptions = signInSnapshot.usernameOptions,
+          canCreateUsername = signInSnapshot.canCreateUsername,
+          canSubmit = true,
+        ),
+      )
+    }
   )
 
   override val model: StateFlow<SignUpModel>

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/ui/UiFactory.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/ui/UiFactory.kt
@@ -10,6 +10,7 @@ import com.wasmo.api.routes.HomeRoute
 import com.wasmo.api.routes.InviteRoute
 import com.wasmo.api.routes.NotFoundRoute
 import com.wasmo.api.routes.Route
+import com.wasmo.api.routes.SignInRoute
 import com.wasmo.api.routes.SignOutRoute
 import com.wasmo.api.routes.SignUpRoute
 import com.wasmo.client.app.buildyours.BuildYoursUi
@@ -54,6 +55,7 @@ class UiFactory(
 
       HomeRoute -> homeUiFactory.create()
 
+      SignInRoute,
       SignUpRoute -> {
         val presenter = signUpPresenterFactory.create()
         signUpUiFactory.create(presenter)

--- a/os/routes/src/commonMain/kotlin/com/wasmo/common/routes/RealRouteCodec.kt
+++ b/os/routes/src/commonMain/kotlin/com/wasmo/common/routes/RealRouteCodec.kt
@@ -11,6 +11,7 @@ import com.wasmo.api.routes.NotFoundRoute
 import com.wasmo.api.routes.Route
 import com.wasmo.api.routes.RouteCodec
 import com.wasmo.api.routes.RoutingContext
+import com.wasmo.api.routes.SignInRoute
 import com.wasmo.api.routes.SignOutRoute
 import com.wasmo.api.routes.SignUpRoute
 import com.wasmo.framework.Url
@@ -43,6 +44,7 @@ class RealRouteCodec(
         "" -> HomeRoute
         "admin" -> AdminRoute
         "build-yours" -> BuildYoursRoute
+        "sign-in" -> SignInRoute
         "sign-out" -> SignOutRoute
         "sign-up" -> SignUpRoute
         else -> NotFoundRoute
@@ -92,6 +94,10 @@ class RealRouteCodec(
 
       SignOutRoute -> routingContext.root.copy(
         path = listOf("sign-out"),
+      )
+
+      SignInRoute -> routingContext.root.copy(
+        path = listOf("sign-in"),
       )
 
       SignUpRoute -> routingContext.root.copy(

--- a/os/server/calls/api/src/jvmMain/kotlin/com/wasmo/calls/CallDataService.kt
+++ b/os/server/calls/api/src/jvmMain/kotlin/com/wasmo/calls/CallDataService.kt
@@ -3,6 +3,7 @@ package com.wasmo.calls
 import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.routes.RouteCodec
 import com.wasmo.api.routes.RoutingContext
 import wasmox.sql.SqlTransaction
@@ -22,6 +23,9 @@ interface CallDataService {
 
   context(sqlTransaction: SqlTransaction)
   suspend fun computerListSnapshot(): ComputerListSnapshot
+
+  context(sqlTransaction: SqlTransaction)
+  suspend fun signInSnapshot(): SignInSnapshot
 
   context(sqlTransaction: SqlTransaction)
   suspend fun inviteTicketOrNull(code: String): InviteTicket?

--- a/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
+++ b/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
@@ -6,6 +6,7 @@ import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListItem
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.LinkedEmailAddressSnapshot
 import com.wasmo.api.LinkedUsernameSnapshot
 import com.wasmo.api.PasskeySnapshot
@@ -20,6 +21,7 @@ import com.wasmo.db.emails.findLinkedEmailAddresses
 import com.wasmo.db.passkeys.DbPasskey
 import com.wasmo.db.passkeys.findPasskeysByAccountId
 import com.wasmo.db.usernames.DbUsername
+import com.wasmo.db.usernames.findUsernamesThatCanSignIn
 import com.wasmo.db.usernames.findUsernameOrNull
 import com.wasmo.identifiers.Deployment
 import com.wasmo.passkeys.AuthenticatorDatabase
@@ -153,6 +155,15 @@ class RealCallDataService(
     }
   }
 
+  private val signInSnapshot = object : DbLazy<SignInSnapshot>() {
+    context(sqlTransaction: SqlTransaction)
+    override suspend fun load(): SignInSnapshot =
+      SignInSnapshot(
+        usernameOptions = findUsernamesThatCanSignIn().map { it.username },
+        canCreateUsername = true,
+      )
+  }
+
   context(sqlTransaction: SqlTransaction)
   override fun onInvalidate() {
     passkeys.invalidate()
@@ -173,6 +184,9 @@ class RealCallDataService(
 
   context(sqlTransaction: SqlTransaction)
   override suspend fun computerListSnapshot() = computerListSnapshot.get()
+
+  context(sqlTransaction: SqlTransaction)
+  override suspend fun signInSnapshot() = signInSnapshot.get()
 
   context(sqlTransaction: SqlTransaction)
   override suspend fun inviteTicketOrNull(code: String): InviteTicket? {

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
@@ -10,6 +10,7 @@ import wasmo.sql.SqlConnection
 import wasmo.sql.SqlException
 import wasmo.sql.SqlRow
 import wasmox.sql.SqlTransaction
+import wasmox.sql.list
 import wasmox.sql.singleOrNull
 
 context(connection: SqlConnection)
@@ -114,6 +115,31 @@ suspend fun findUsernameOrNull(
     bindS64(1, 1)
   }
   return rowIterator.singleOrNull {
+    getUsername()
+  }
+}
+
+context(connection: SqlConnection)
+suspend fun findUsernamesThatCanSignIn(
+  limit: Long = Long.MAX_VALUE,
+): List<DbUsername> {
+  val rowIterator = connection.executeQuery(
+    """
+    SELECT
+      id,
+      created_at,
+      account_id,
+      username,
+      deleted_at
+    FROM Username
+    WHERE deleted_at IS NULL
+    ORDER BY username ASC
+    LIMIT $1
+    """,
+  ) {
+    bindS64(0, limit)
+  }
+  return rowIterator.list {
     getUsername()
   }
 }

--- a/os/server/website/api/src/jvmMain/kotlin/com/wasmo/website/ServerOsHtml.kt
+++ b/os/server/website/api/src/jvmMain/kotlin/com/wasmo/website/ServerOsHtml.kt
@@ -4,6 +4,7 @@ import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.ComputerSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.OsHtml
 import com.wasmo.api.routes.RoutingContext
 import com.wasmo.framework.Response
@@ -21,6 +22,7 @@ interface ServerOsHtml : OsHtml {
       inviteTicket: InviteTicket? = null,
       computerSnapshot: ComputerSnapshot? = null,
       computerListSnapshot: ComputerListSnapshot? = null,
+      signInSnapshot: SignInSnapshot? = null,
     ): ServerOsHtml
   }
 }

--- a/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/OsPage.kt
+++ b/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/OsPage.kt
@@ -10,6 +10,7 @@ import com.wasmo.api.routes.ComputerHomeRoute
 import com.wasmo.api.routes.HomeRoute
 import com.wasmo.api.routes.InviteRoute
 import com.wasmo.api.routes.RoutingContext
+import com.wasmo.api.routes.SignInRoute
 import com.wasmo.api.routes.SignUpRoute
 import com.wasmo.calls.CallDataService
 import com.wasmo.computers.ComputerService
@@ -50,8 +51,14 @@ class OsPage(
       accountSnapshot = callDataService.accountSnapshot()
       routingContext = callDataService.routingContext()
       val routeCodec = callDataService.routeCodec()
+      val route = routeCodec.decode(url)
 
-      when (val route = routeCodec.decode(url)) {
+      // Home can also handle sign-in as a Single-Page Application, so it needs signInSnapshot.
+      if (route is HomeRoute || route is SignInRoute) {
+        // TODO: Make SignInSnapshot responsible for all sign-in options, not only username.
+        signInSnapshot = callDataService.signInSnapshot().takeIf { it.usernameOptions.isNotEmpty() }
+      }
+      when (route) {
         is ComputerHomeRoute -> {
           computerService = computerStore.getOrNull(client, route.slug)
             ?: throw UnauthorizedUserException()
@@ -64,12 +71,6 @@ class OsPage(
         is InviteRoute -> {
           inviteTicket = callDataService.inviteTicketOrNull(route.code)
             ?: throw NotFoundUserException()
-        }
-
-        is SignUpRoute -> {
-          // TODO: Add SignInRoute, add signInSnapshot only there
-          // TODO: Make SignInSnapshot responsible for all sign-in options, not only username.
-          signInSnapshot = callDataService.signInSnapshot().takeIf { it.usernameOptions.isNotEmpty() }
         }
 
         else -> {

--- a/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/OsPage.kt
+++ b/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/OsPage.kt
@@ -5,10 +5,12 @@ import com.wasmo.accounts.Client
 import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.routes.ComputerHomeRoute
 import com.wasmo.api.routes.HomeRoute
 import com.wasmo.api.routes.InviteRoute
 import com.wasmo.api.routes.RoutingContext
+import com.wasmo.api.routes.SignUpRoute
 import com.wasmo.calls.CallDataService
 import com.wasmo.computers.ComputerService
 import com.wasmo.computers.ComputerStore
@@ -42,6 +44,7 @@ class OsPage(
     var inviteTicket: InviteTicket? = null
     var computerService: ComputerService? = null
     var computerListSnapshot: ComputerListSnapshot? = null
+    var signInSnapshot: SignInSnapshot? = null
 
     wasmoDb.transaction {
       accountSnapshot = callDataService.accountSnapshot()
@@ -63,6 +66,12 @@ class OsPage(
             ?: throw NotFoundUserException()
         }
 
+        is SignUpRoute -> {
+          // TODO: Add SignInRoute, add signInSnapshot only there
+          // TODO: Make SignInSnapshot responsible for all sign-in options, not only username.
+          signInSnapshot = callDataService.signInSnapshot().takeIf { it.usernameOptions.isNotEmpty() }
+        }
+
         else -> {
         }
       }
@@ -74,6 +83,7 @@ class OsPage(
       inviteTicket = inviteTicket,
       computerSnapshot = computerService?.snapshot(),
       computerListSnapshot = computerListSnapshot,
+      signInSnapshot = signInSnapshot,
     )
   }
 

--- a/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/RealServerOsHtml.kt
+++ b/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/RealServerOsHtml.kt
@@ -4,6 +4,7 @@ import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.ComputerSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.WasmoJson
 import com.wasmo.api.routes.RoutingContext
 import com.wasmo.api.stripe.StripePublishableKey
@@ -35,6 +36,7 @@ class RealServerOsHtml(
   @Assisted override val inviteTicket: InviteTicket?,
   @Assisted override val computerSnapshot: ComputerSnapshot?,
   @Assisted override val computerListSnapshot: ComputerListSnapshot?,
+  @Assisted override val signInSnapshot: SignInSnapshot?,
 ) : ServerOsHtml, ResponseBody {
   val pageData: MapPageData
     get() = MapPageData.Builder(WasmoJson)
@@ -50,6 +52,9 @@ class RealServerOsHtml(
         }
         if (computerListSnapshot != null) {
           put("computer_list_snapshot", computerListSnapshot)
+        }
+        if (signInSnapshot != null) {
+          put("sign_in_snapshot", signInSnapshot)
         }
       }
       .build()
@@ -127,6 +132,7 @@ class RealServerOsHtml(
       inviteTicket: InviteTicket?,
       computerSnapshot: ComputerSnapshot?,
       computerListSnapshot: ComputerListSnapshot?,
+      signInSnapshot: SignInSnapshot?,
     ): RealServerOsHtml
   }
 }

--- a/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/WebsiteBindings.kt
+++ b/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/WebsiteBindings.kt
@@ -49,6 +49,11 @@ abstract class WebsiteBindings {
 
       pageRegistration(
         host = hostnamePatterns.osHostname,
+        path = "/sign-in",
+      ),
+
+      pageRegistration(
+        host = hostnamePatterns.osHostname,
         path = "/sign-up",
       ),
 


### PR DESCRIPTION
I plan to merge this together with the follow-up PR https://github.com/wasmcomputercompany/wasmo/pull/45

---

Right now, SignInSnapshot is username-centric:
 - OsPage adds it iff a username exists in the DB.
 - SignUpPresenter uses its presence to switch between email vs.
   username sign-in

TODO:
 - Make SignInSnapshot the model controlling all sign-in options.
 - Introduce /sign-in route; usernames from DB should only be shown on
   /sign-in, not on /sign-up
 - Server-side endpoint to link selected username to account.