### PR TITLE
show account in home page footer

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/AccountSnapshot.kt
@@ -14,8 +14,12 @@ data class AccountSnapshot(
   val emailAddresses: List<LinkedEmailAddressSnapshot>,
   val username: LinkedUsernameSnapshot?,
   val hasInvite: Boolean,
-  val isSignedIn: Boolean,
-)
+  /** Suitable for identifying the signed-in account in the UI, or null if not signed-in. */
+  val signedInAccountName: String?,
+) {
+  val isSignedIn: Boolean
+    get() = signedInAccountName != null
+}
 
 @Serializable
 data object AccountSnapshotRequest

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeScreen.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeScreen.kt
@@ -18,7 +18,9 @@ import org.jetbrains.compose.web.css.height
 import org.jetbrains.compose.web.css.percent
 import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.dom.DOMScope
+import org.jetbrains.compose.web.dom.Footer
 import org.jetbrains.compose.web.dom.Section
+import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 
@@ -29,6 +31,7 @@ fun HomeScreen(
   items: List<Item>,
   showNewComputer: Boolean,
   eventListener: (HomeEvent) -> Unit,
+  footerText: String?,
 ) {
   HomeScreen(
     attrs = attrs,
@@ -69,6 +72,15 @@ fun HomeScreen(
               classes("ContentWidth")
             },
           )
+        }
+        if (footerText != null) {
+          Footer(
+            attrs = {
+              classes("Homescreen", "Footer")
+            }
+          ) {
+            Text(footerText)
+          }
         }
       }
     },

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/home/HomeUi.kt
@@ -57,6 +57,7 @@ class HomeUi(
         )
       },
       showNewComputer = environment.showSignUp && accountSnapshot.isSignedIn,
+      footerText = accountSnapshot.signedInAccountName,
     )
   }
 

--- a/os/client/style/src/jvmMain/resources/static/assets/Wasmo.css
+++ b/os/client/style/src/jvmMain/resources/static/assets/Wasmo.css
@@ -386,6 +386,11 @@ button {
   color: rgba(0 0 0 / 0.8);
 }
 
+.HomeScreen .Footer {
+  color: rgba(255 255 255 / 0.5);
+  font-size: 16px;
+}
+
 .HomeScreen .SmartphoneFrame {
   cursor: pointer;
 }

--- a/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
+++ b/os/server/calls/real/src/jvmMain/kotlin/com/wasmo/calls/RealCallDataService.kt
@@ -131,7 +131,8 @@ class RealCallDataService(
         emailAddresses = emailAddresses,
         username = linkedUsername.get(),
         hasInvite = firstInvite != null,
-        isSignedIn = emailAddresses.isNotEmpty() || linkedUsername.get() != null,
+        signedInAccountName = linkedUsername.get()?.username?.value
+          ?: emailAddresses.firstOrNull()?.emailAddress
       )
     }
   }


### PR DESCRIPTION
Show the signed-in accountName (username or email), if any, in a footer on the home page.

<img width="1299" height="778" alt="Screenshot From 2026-05-16 22-16-22" src="https://github.com/user-attachments/assets/bb7ddc03-ef78-448c-b23a-bcda6f860e08" />
