### PR TITLE
selectLinkedUsernameOrNull(): get rid of allowDeleted: Bool parameter

### DIFF
--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
@@ -72,7 +72,6 @@ suspend fun replaceUsername(
 
 /**
  * Marks [username] for the given [accountId] as deleted at [deletedAt].
- * A deleted username will no longer be found by [selectUsernameOrNull].
  * Deletion is meant to be permanent, but we might some dayy want to offer
  * un-deletion/reuse to the account originally owning the username.
  */
@@ -123,7 +122,12 @@ suspend fun findUsernameOrNull(
 context(connection: SqlConnection)
 suspend fun selectLinkedUsernameOrNull(
   username: UsernameSlug,
-  allowDeleted: Boolean = false,
+): DbUsername? =
+  selectLinkedUsernameOrNullAllowDeleted(username)?.takeIf { it.deletedAt == null }
+
+context(connection: SqlConnection)
+suspend fun selectLinkedUsernameOrNullAllowDeleted(
+  username: UsernameSlug,
 ): DbUsername? {
   val rowIterator = connection.executeQuery(
     """
@@ -134,12 +138,11 @@ suspend fun selectLinkedUsernameOrNull(
       username,
       deleted_at
     FROM Username
-    WHERE username = $1 AND ($2 OR deleted_at IS NULL)
+    WHERE username = $1
     LIMIT 1
     """,
   ) {
     bindUsername(0, username)
-    bindBool(1, allowDeleted)
   }
   return rowIterator.singleOrNull {
     getUsername()

--- a/os/server/usernames/real/src/jvmMain/kotlin/com/wasmo/usernames/RealUsernameLinker.kt
+++ b/os/server/usernames/real/src/jvmMain/kotlin/com/wasmo/usernames/RealUsernameLinker.kt
@@ -6,6 +6,7 @@ import com.wasmo.api.UsernameDecision
 import com.wasmo.calls.CallDataService
 import com.wasmo.db.usernames.insertUsername
 import com.wasmo.db.usernames.selectLinkedUsernameOrNull
+import com.wasmo.db.usernames.selectLinkedUsernameOrNullAllowDeleted
 import com.wasmo.identifiers.UsernameSlug
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -48,7 +49,7 @@ class RealUsernameLinker(
     try {
       val now = clock.now()
       val accountId = client.getOrCreateAccountId()
-      val existingUsername = selectLinkedUsernameOrNull(username = username, allowDeleted = true)
+      val existingUsername = selectLinkedUsernameOrNullAllowDeleted(username = username)
       if (existingUsername?.deletedAt != null) {
         return UsernameDecision.UsernameDeleted // username exists but was deleted
       }


### PR DESCRIPTION
- split `selectLinkedUsernameOrNull()` into two methods
- since the version that allows deleted usernames returns at most one result, implement the version that doesn't on top of it and filter out a potentially deleted username at the Kotlin rather than postgresql level.

Returning deleted usernames is normally the surprising case, therefore the function that does has a slightly unwieldy `AllowDeleted` suffix; in this particular case though, it's the only one of the two functions that's currently being used.