### PR TITLE
Offer free computers on Homelab.

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/ComputerSpec.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/ComputerSpec.kt
@@ -1,6 +1,7 @@
 package com.wasmo.api
 
 import com.wasmo.identifiers.ComputerSlug
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,6 +11,12 @@ data class CreateComputerSpecRequest(
 )
 
 @Serializable
-data class CreateComputerSpecResponse(
-  val checkoutSessionClientSecret: String,
-)
+sealed class CreateComputerSpecResponse {
+  @Serializable
+  @SerialName("PaymentRequired")
+  data class PaymentRequired(val checkoutSessionClientSecret: String) : CreateComputerSpecResponse()
+
+  @Serializable
+  @SerialName("Success")
+  data object Success : CreateComputerSpecResponse()
+}

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/buildyours/BuildYours.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/buildyours/BuildYours.kt
@@ -161,6 +161,7 @@ fun BuildYoursScreen(
         }
       }
 
+      // TODO: Make options and their pricing (including free) configurable by the server.
       Section {
         H2 {
           Text("Start with this:")
@@ -191,11 +192,11 @@ fun BuildYoursScreen(
         Button(
           attrs = {
             onClick {
-              eventListener(BuildYoursScreenEvent.ClickCheckOut(ComputerSlug(nameState)))
+              eventListener(BuildYoursScreenEvent.ClickCreateComputer(ComputerSlug(nameState)))
             }
           },
         ) {
-          Text("Check Out")
+          Text("Create Computer")
         }
       }
 
@@ -216,7 +217,7 @@ fun BuildYoursScreen(
 }
 
 sealed interface BuildYoursScreenEvent {
-  data class ClickCheckOut(
+  data class ClickCreateComputer(
     val slug: ComputerSlug,
   ) : BuildYoursScreenEvent
 

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/buildyours/BuildYoursUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/buildyours/BuildYoursUi.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.wasmo.api.CreateComputerSpecRequest
+import com.wasmo.api.CreateComputerSpecResponse
+import com.wasmo.api.WasmoApi
+import com.wasmo.api.routes.ComputerHomeRoute
 import com.wasmo.api.routes.HomeRoute
 import com.wasmo.client.app.routing.Router
 import com.wasmo.client.app.routing.TransitionDirection
@@ -15,6 +18,7 @@ import com.wasmo.support.tokens.newToken
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.web.attributes.AttrsScope
 import org.w3c.dom.HTMLElement
 
@@ -23,6 +27,7 @@ class BuildYoursUi(
   private val coroutineScope: CoroutineScope,
   private val checkoutSessionFactory: CheckoutSession.Factory,
   private val router: Router,
+  private val wasmoApi: WasmoApi,
 ) : Ui {
   private val computerSpecToken = newToken()
   private var checkoutSessionState by mutableStateOf<CheckoutSession?>(null)
@@ -45,14 +50,26 @@ class BuildYoursUi(
 
   fun onEvent(it: BuildYoursScreenEvent) {
     when (it) {
-      is BuildYoursScreenEvent.ClickCheckOut -> {
-        checkoutSessionState = checkoutSessionFactory.create(
-          coroutineScope,
-          CreateComputerSpecRequest(
-            computerSpecToken = computerSpecToken,
-            slug = it.slug,
-          ),
+      is BuildYoursScreenEvent.ClickCreateComputer -> {
+        val computerSlug = it.slug
+        val createComputerSpecRequest = CreateComputerSpecRequest(
+          computerSpecToken = computerSpecToken,
+          slug = computerSlug,
         )
+        coroutineScope.launch {
+          val createComputerSpecResponse = wasmoApi.createComputerSpec(createComputerSpecRequest)
+          when (createComputerSpecResponse) {
+            CreateComputerSpecResponse.Success -> {
+              router.goTo(ComputerHomeRoute(computerSlug), TransitionDirection.POP)
+            }
+            is CreateComputerSpecResponse.PaymentRequired -> {
+              checkoutSessionState = checkoutSessionFactory.create(
+                coroutineScope = coroutineScope,
+                clientSecret =  createComputerSpecResponse.checkoutSessionClientSecret,
+              )
+            }
+          }
+        }
       }
 
       BuildYoursScreenEvent.ClickQuestions -> {

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/stripe/CheckoutSession.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/stripe/CheckoutSession.kt
@@ -1,7 +1,5 @@
 package com.wasmo.client.app.stripe
 
-import com.wasmo.api.CreateComputerSpecRequest
-import com.wasmo.api.WasmoApi
 import com.wasmo.api.stripe.StripePublishableKey
 import com.wasmo.client.identifiers.ClientAppScope
 import com.wasmo.compose.Checkout
@@ -9,11 +7,10 @@ import com.wasmo.compose.InitEmbeddedCheckoutOptions
 import com.wasmo.compose.Stripe
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlin.js.Promise
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.asDeferred
-import kotlinx.coroutines.asPromise
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.w3c.dom.Element
 
@@ -44,21 +41,15 @@ class CheckoutSession private constructor(
   @SingleIn(ClientAppScope::class)
   class Factory(
     private val stripePublishableKey: StripePublishableKey,
-    private val wasmoApi: WasmoApi,
   ) {
     fun create(
       coroutineScope: CoroutineScope,
-      createComputerSpecRequest: CreateComputerSpecRequest,
+      clientSecret: String,
     ): CheckoutSession {
       val stripe = Stripe(stripePublishableKey.publishableKey)
       val deferredCheckout = stripe.initEmbeddedCheckout(
         InitEmbeddedCheckoutOptions(
-          fetchClientSecret = {
-            coroutineScope.async {
-              val response = wasmoApi.createComputerSpec(createComputerSpecRequest)
-              response.checkoutSessionClientSecret
-            }.asPromise()
-          },
+          fetchClientSecret = { Promise.resolve(clientSecret) },
         ),
       ).asDeferred()
 

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
@@ -10,6 +10,7 @@ import com.wasmo.common.catalog.Catalog
 import com.wasmo.common.routes.RealRouteCodec
 import com.wasmo.computers.ComputerServiceGraph
 import com.wasmo.computers.ComputersBindings
+import com.wasmo.computers.free.FreeComputersBindings
 import com.wasmo.db.Migrator
 import com.wasmo.emails.EmailBindings
 import com.wasmo.identifiers.Deployment
@@ -48,6 +49,7 @@ import wasmo.sql.SqlDatabase
     AccountsBindings::class,
     AccountsPasskeysBindings::class,
     ComputersBindings::class,
+    FreeComputersBindings::class,
     EmailBindings::class,
     FileSystemObjectStoreBindings::class,
     InstalledAppBindings::class,

--- a/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedGraph.kt
+++ b/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedGraph.kt
@@ -8,6 +8,7 @@ import com.wasmo.calls.CallGraph
 import com.wasmo.common.catalog.Catalog
 import com.wasmo.computers.ComputerServiceGraph
 import com.wasmo.computers.ComputersBindings
+import com.wasmo.computers.paid.PaidComputersBindings
 import com.wasmo.db.Migrator
 import com.wasmo.db.RealMigrator
 import com.wasmo.emails.EmailBindings
@@ -46,6 +47,7 @@ import wasmo.sql.SqlDatabase
     AccountsBindings::class,
     AccountsPasskeysBindings::class,
     ComputersBindings::class,
+    PaidComputersBindings::class,
     EmailBindings::class,
     FileSystemObjectStoreBindings::class,
     InstalledAppBindings::class,

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxGraph.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxGraph.kt
@@ -8,6 +8,7 @@ import com.wasmo.calls.CallGraph
 import com.wasmo.common.catalog.Catalog
 import com.wasmo.computers.ComputerServiceGraph
 import com.wasmo.computers.ComputersBindings
+import com.wasmo.computers.paid.PaidComputersBindings
 import com.wasmo.db.Migrator
 import com.wasmo.db.RealMigrator
 import com.wasmo.emails.EmailBindings
@@ -46,6 +47,7 @@ import wasmo.sql.SqlDatabase
     AccountsBindings::class,
     AccountsPasskeysBindings::class,
     ComputersBindings::class,
+    PaidComputersBindings::class,
     EmailBindings::class,
     FileSystemObjectStoreBindings::class,
     InstalledAppBindings::class,

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/ComputersBindings.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/ComputersBindings.kt
@@ -9,7 +9,6 @@ import com.wasmo.jobs.JobRegistration
 import com.wasmo.jobs.OsJobQueue
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Binds
-import dev.zacsweers.metro.ElementsIntoSet
 import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -24,23 +23,16 @@ abstract class ComputersBindings {
     private val InstallAppJobName = JobName<InstallAppJob, Unit>("InstallAppJob")
 
     @Provides
-    @ElementsIntoSet
+    @IntoSet
     @SingleIn(OsScope::class)
     fun provideActionRegistrations(
       hostnamePatterns: HostnamePatterns,
-    ): List<ActionRegistration> = listOf(
-      ActionRegistration.Rpc(
-        host = hostnamePatterns.osHostname,
-        path = "/create-computer-spec",
-        action = CreateComputerSpecRpc::class,
-      ),
-
+    ): ActionRegistration =
       ActionRegistration.Rpc(
         host = hostnamePatterns.computerRegex,
         path = "/install-app",
         action = InstallAppRpc::class,
-      ),
-    )
+      )
 
     @Provides
     @SingleIn(OsScope::class)

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeComputersBindings.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeComputersBindings.kt
@@ -1,0 +1,26 @@
+package com.wasmo.computers.free
+
+import com.wasmo.framework.ActionRegistration
+import com.wasmo.identifiers.HostnamePatterns
+import com.wasmo.identifiers.OsScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@BindingContainer
+abstract class FreeComputersBindings {
+  companion object {
+    @Provides
+    @IntoSet
+    @SingleIn(OsScope::class)
+    fun provideActionRegistrations(
+        hostnamePatterns: HostnamePatterns,
+    ): ActionRegistration =
+      ActionRegistration.Rpc(
+        host = hostnamePatterns.osHostname,
+        path = "/create-computer-spec",
+        action = FreeCreateComputerSpecRpc::class,
+      )
+  }
+}

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeCreateComputerSpecRpc.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeCreateComputerSpecRpc.kt
@@ -1,0 +1,73 @@
+package com.wasmo.computers.free
+
+import com.wasmo.accounts.CallScope
+import com.wasmo.accounts.Client
+import com.wasmo.api.CreateComputerSpecRequest
+import com.wasmo.api.CreateComputerSpecResponse
+import com.wasmo.computers.ComputerSpecStore
+import com.wasmo.computers.ComputerStore
+import com.wasmo.db.computers.insertComputerAllocation
+import com.wasmo.framework.Response
+import com.wasmo.framework.RpcAction
+import com.wasmo.framework.Url
+import com.wasmo.identifiers.StripeCustomerId
+import com.wasmo.payments.ComputerAllocationSnapshot
+import dev.zacsweers.metro.ClassKey
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import wasmo.sql.SqlDatabase
+import wasmox.sql.transaction
+
+@Inject
+@ClassKey(FreeCreateComputerSpecRpc::class)
+@ContributesIntoMap(CallScope::class, binding = binding<RpcAction<*, *>>())
+class FreeCreateComputerSpecRpc(
+  private val client: Client,
+  private val wasmoDb: SqlDatabase,
+  private val computerSpecStore: ComputerSpecStore,
+  private val computerStore: ComputerStore,
+  private val clock: Clock,
+) : RpcAction<CreateComputerSpecRequest, CreateComputerSpecResponse.Success> {
+  suspend fun create(
+    request: CreateComputerSpecRequest,
+  ): Response<CreateComputerSpecResponse.Success> {
+    wasmoDb.transaction {
+      computerSpecStore.insertIfAbsent(
+        accountId = client.getOrCreateAccountId(),
+        slug = request.slug,
+        computerSpecToken = request.computerSpecToken,
+      )
+      val computer = computerStore.initializeFromSpec(request.computerSpecToken)
+      val now = clock.now()
+
+      // TODO: Replace these fake values with something better; make the fields nullable?
+      val stripeCustomerId = StripeCustomerId(-1)
+      val stripeSubscriptinId = ""
+      val activeEnd = now.plus(36525.days) // approx. 100 years,
+
+      insertComputerAllocation(
+        created_at = now,
+        version = 1,
+        stripe_customer_id = stripeCustomerId,
+        stripe_subscription_id = stripeSubscriptinId,
+        computer_id = computer.id,
+        active_start = now,
+        active_end = activeEnd,
+      )
+
+    }
+    return Response(
+      body = CreateComputerSpecResponse.Success,
+    )
+  }
+
+  override suspend operator fun invoke(
+    request: CreateComputerSpecRequest,
+    url: Url,
+  ) = create(request)
+
+}

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidComputersBindings.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidComputersBindings.kt
@@ -1,0 +1,26 @@
+package com.wasmo.computers.paid
+
+import com.wasmo.framework.ActionRegistration
+import com.wasmo.identifiers.HostnamePatterns
+import com.wasmo.identifiers.OsScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@BindingContainer
+abstract class PaidComputersBindings {
+  companion object {
+    @Provides
+    @IntoSet
+    @SingleIn(OsScope::class)
+    fun provideActionRegistrations(
+        hostnamePatterns: HostnamePatterns,
+    ): ActionRegistration =
+      ActionRegistration.Rpc(
+        host = hostnamePatterns.osHostname,
+        path = "/create-computer-spec",
+        action = PaidCreateComputerSpecRpc::class,
+      )
+  }
+}

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidCreateComputerSpecRpc.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidCreateComputerSpecRpc.kt
@@ -1,9 +1,10 @@
-package com.wasmo.computers
+package com.wasmo.computers.paid
 
 import com.wasmo.accounts.CallScope
 import com.wasmo.accounts.Client
 import com.wasmo.api.CreateComputerSpecRequest
 import com.wasmo.api.CreateComputerSpecResponse
+import com.wasmo.computers.ComputerSpecStore
 import com.wasmo.framework.Response
 import com.wasmo.framework.RpcAction
 import com.wasmo.framework.Url
@@ -17,17 +18,17 @@ import wasmo.sql.SqlDatabase
 import wasmox.sql.transaction
 
 @Inject
-@ClassKey(CreateComputerSpecRpc::class)
+@ClassKey(PaidCreateComputerSpecRpc::class)
 @ContributesIntoMap(CallScope::class, binding = binding<RpcAction<*, *>>())
-class CreateComputerSpecRpc(
+class PaidCreateComputerSpecRpc(
   private val paymentsService: PaymentsService,
   private val client: Client,
   private val wasmoDb: SqlDatabase,
   private val computerSpecStore: ComputerSpecStore,
-) : RpcAction<CreateComputerSpecRequest, CreateComputerSpecResponse> {
+) : RpcAction<CreateComputerSpecRequest, CreateComputerSpecResponse.PaymentRequired> {
   suspend fun create(
     request: CreateComputerSpecRequest,
-  ): Response<CreateComputerSpecResponse> {
+  ): Response<CreateComputerSpecResponse.PaymentRequired> {
     wasmoDb.transaction {
       computerSpecStore.insertIfAbsent(
         accountId = client.getOrCreateAccountId(),
@@ -41,7 +42,7 @@ class CreateComputerSpecRpc(
     )
 
     return Response(
-      body = CreateComputerSpecResponse(
+      body = CreateComputerSpecResponse.PaymentRequired(
         checkoutSessionClientSecret = checkoutSession.clientSecret,
       ),
     )

--- a/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/call/CallTester.kt
+++ b/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/call/CallTester.kt
@@ -21,15 +21,14 @@ import com.wasmo.api.SignOutRequest
 import com.wasmo.api.routes.Route
 import com.wasmo.api.routes.RouteCodec
 import com.wasmo.api.routes.RoutingContext
-import com.wasmo.computers.CreateComputerSpecRpc
 import com.wasmo.computers.InstallAppRpc
+import com.wasmo.computers.paid.PaidCreateComputerSpecRpc
 import com.wasmo.emails.ConfirmEmailAddressRpc
 import com.wasmo.emails.LinkEmailAddressRpc
 import com.wasmo.framework.Request
 import com.wasmo.framework.Url
 import com.wasmo.identifiers.ComputerSlug
 import com.wasmo.identifiers.Deployment
-import com.wasmo.identifiers.UsernameSlug
 import com.wasmo.installedapps.CallAppAction
 import com.wasmo.stripe.AfterCheckoutPage
 import com.wasmo.support.tokens.ChallengeCode
@@ -57,7 +56,7 @@ class CallTester(
   private val authenticatePasskeyRpcProvider: Provider<AuthenticatePasskeyRpc>,
   private val callAppActionProvider: Provider<CallAppAction>,
   private val confirmEmailAddressRpcProvider: Provider<ConfirmEmailAddressRpc>,
-  private val createComputerSpecRpcProvider: Provider<CreateComputerSpecRpc>,
+  private val createComputerSpecRpcProvider: Provider<PaidCreateComputerSpecRpc>,
   private val createInviteRpcProvider: Provider<CreateInviteRpc>,
   private val createUsernanmeRpcProvider: Provider<CreateUsernameRpc>,
   private val installAppRpcProvider: Provider<InstallAppRpc>,


### PR DESCRIPTION
I've only tested this on Homelab, I don't know if I have broken hosted/sandbox.

 - CreateComputerSpecResponse is now a sealed class { PaymentRequired(clientSecret), Success }
 - BuildYours / BuildYoursUi: 'Check Out' button becomes 'Create Computer', checkout flow is skipped for Homelab (go straight back to home).
 - Free/Paid distinction is done server side via {Free,Paid}ComputerBindings which bind {Free,Paid}CreateComputerSpecRpc. Homelab uses Free, Sandbox/Hosted use Paid.
 - There are some bugs (app icons, computers only show on page reload)
   but it sounds like that's a preexisting bug on other Distributions
   too (I haven't tried those).

TODO for later PRs:
 - Figure out what to do about stripe-specific columns in ComputerAllocation table. FreeCreateCommputerSpecRpc currently uses hard-coded fake values.
 - Fix UI transition bugs that currently require page reload.