### PR TITLE
Allow uppercase characters and limited punctuation in usernames.

### DIFF
--- a/identifiers/src/commonMain/kotlin/com/wasmo/identifiers/UsernameSlug.kt
+++ b/identifiers/src/commonMain/kotlin/com/wasmo/identifiers/UsernameSlug.kt
@@ -3,20 +3,32 @@ package com.wasmo.identifiers
 import kotlin.jvm.JvmInline
 import kotlinx.serialization.Serializable
 
-@JvmInline
+/**
+ * A valid username. All characters allowable in a username are URL safe.
+ */
 @Serializable
+@JvmInline
 value class UsernameSlug(val value: String) {
+
   init {
-    require(value.matches(UsernameSlugRegex)) {
+    require(isUsernameValid(value)) {
       "invalid username: $value"
     }
   }
 
-  companion object {
-    fun of(unnormalizedValue: String) = UsernameSlug(unnormalizedValue.lowercase())
-  }
-
+  // DB required normalizedValue to be UNIQUE among usernames
+  val normalizedValue: String
+    get() = value.replace(Regex("[._-]"), "").lowercase()
 }
 
-/** Between 1 and 15 lowercase (for case insensitivity) letters or digits, and the first is not a digit. */
-val UsernameSlugRegex = Regex("[a-z][a-z0-9]{0,14}")
+/**
+ * 3-20 characters that are alphanumeric or limited punctuation `[._-]`. No punctuation in first or
+ * last position, and not more than one in a row. No digits [0-9] in the first position.
+ */
+private val UsernameSlugRegex = Regex("^[a-zA-Z][a-zA-Z0-9._-]+[a-zA-Z0-9]$")
+
+fun isUsernameValid(usernameString: String): Boolean =
+  // Check the length first rather than get DoSed matching the regex against a very long String
+  usernameString.length in 3..20
+    && UsernameSlugRegex.matches(usernameString)
+    && Regex("[._-]{2}") !in usernameString

--- a/identifiers/src/commonTest/kotlin/com/wasmo/identifiers/UsernameSlugTest.kt
+++ b/identifiers/src/commonTest/kotlin/com/wasmo/identifiers/UsernameSlugTest.kt
@@ -1,0 +1,136 @@
+package com.wasmo.identifiers
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UsernameSlugTest {
+
+  @Test
+  fun `Usernames must be between 3 and 20 characters long`() {
+    assertThat(isUsernameValid("")).isFalse()
+    assertThat(isUsernameValid("a")).isFalse()
+    assertThat(isUsernameValid("ab")).isFalse()
+
+    assertThat(isUsernameValid("aac")).isTrue()
+    assertThat(isUsernameValid("aaaa")).isTrue()
+    assertThat(isUsernameValid("a".repeat(19))).isTrue()
+    assertThat(isUsernameValid("a".repeat(20))).isTrue()
+
+    assertThat(isUsernameValid("a".repeat(21))).isFalse()
+    assertThat(isUsernameValid("a".repeat(22))).isFalse()
+    assertThat(isUsernameValid("a".repeat(10000))).isFalse()
+  }
+
+  @Test
+  fun `Uppercase and punctuation characters are preserved but stripped from DB form`() {
+    val username = UsernameSlug("J_o_h_n.D-o-e")
+    assertEquals("J_o_h_n.D-o-e", username.value)
+    assertEquals("johndoe", username.normalizedValue)
+  }
+
+  @Test
+  fun `No punctuation characters in first or last position`() {
+    assertThat(isUsernameValid("-JohnDoe")).isFalse()
+    assertThat(isUsernameValid("_JohnDoe")).isFalse()
+    assertThat(isUsernameValid(".JohnDoe")).isFalse()
+    assertThat(isUsernameValid("JohnDoe-")).isFalse()
+    assertThat(isUsernameValid("JohnDoe_")).isFalse()
+    assertThat(isUsernameValid("JohnDoe.")).isFalse()
+
+    // For comparison, these are valid
+    assertThat(isUsernameValid("John.Doe")).isTrue()
+    assertThat(isUsernameValid("John.doE")).isTrue()
+  }
+
+  @Test
+  fun `No more than one punctuation character in a row`() {
+    assertThat(isUsernameValid("John--Doe")).isFalse()
+    assertThat(isUsernameValid("John__Doe")).isFalse()
+    assertThat(isUsernameValid("John...Doe")).isFalse()
+    assertThat(isUsernameValid("John-_Doe")).isFalse()
+    assertThat(isUsernameValid("John._Doe")).isFalse()
+    assertThat(isUsernameValid("John-._Doe")).isFalse()
+
+    // For comparison, these are valid
+    assertThat(isUsernameValid("John.Doe")).isTrue()
+    assertThat(isUsernameValid("J-o-h-n_D.o.e")).isTrue()
+    assertThat(isUsernameValid("John_Doe")).isTrue()
+  }
+
+  @Test
+  fun `Sequences of digits 0-9 are allowed except in the first position`() {
+    assertThat(isUsernameValid("jesse123")).isTrue()
+    assertThat(isUsernameValid("jesse.123")).isTrue()
+    assertThat(isUsernameValid("j01e23s45s67e89")).isTrue()
+    assertThat(isUsernameValid("jesse123Wilson")).isTrue()
+
+    assertThat(isUsernameValid("1jesse")).isFalse()
+    assertThat(isUsernameValid("42jesse")).isFalse()
+  }
+
+  @Test
+  fun `No empty string`() {
+    assertThat(isUsernameValid("")).isFalse()
+  }
+
+  @Test
+  fun `Constructor throws IAE on invalid username`() {
+    val invalidUsernameString = "1"
+
+    assertFailsWith<IllegalArgumentException> { UsernameSlug(invalidUsernameString) }
+
+    // Check this test's assumptions
+    assertThat(isUsernameValid(invalidUsernameString)).isFalse()
+  }
+
+  @Test
+  fun `no accents or umlauts`() {
+    // accents
+    assertThat(isUsernameValid("quéstionable")).isFalse()
+    assertThat(isUsernameValid("quëstionable")).isFalse()
+    assertThat(isUsernameValid("quèstionable")).isFalse()
+
+    // umlauts
+    assertThat(isUsernameValid("questionÄble")).isFalse()
+    assertThat(isUsernameValid("questionäble")).isFalse()
+    assertThat(isUsernameValid("questiÖnable")).isFalse()
+    assertThat(isUsernameValid("questiönable")).isFalse()
+    assertThat(isUsernameValid("qÜestionable")).isFalse()
+    assertThat(isUsernameValid("qüestionable")).isFalse()
+
+    // Other than the illegal characters, it would have been fine
+    assertThat(isUsernameValid("questionable")).isTrue()
+  }
+
+  // If the normalization algorithm changes, we need a DB migration to persisted normalized
+  // values.
+  @Test
+  fun `Normalization algorithm has not changed`() {
+    assertEquals("john123doe", UsernameSlug("J_o.H-n.1-23D_oE").normalizedValue)
+  }
+
+  @Test
+  fun `toString equals and hashCode are based on String value`() {
+    val username = UsernameSlug("jesse.123")
+    assertThat(username.hashCode()).isEqualTo("jesse.123".hashCode())
+    assertThat(username).isEqualTo(UsernameSlug("jesse.123"))
+  }
+
+  @Test
+  fun `equals is based on value not normalizedValue`() {
+    val username = UsernameSlug("jesse.123")
+    val other = UsernameSlug("jesse123")
+    // check an assumption of this test
+    assertThat(username.normalizedValue).isEqualTo(other.normalizedValue)
+
+    assertThat(username).isEqualTo(UsernameSlug("jesse.123"))
+    assertThat(username).isNotEqualTo(other)
+  }
+
+}

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
@@ -10,7 +10,7 @@ import com.wasmo.client.app.routing.Router
 import com.wasmo.client.app.routing.TransitionDirection
 import com.wasmo.client.framework.Presenter
 import com.wasmo.identifiers.UsernameSlug
-import com.wasmo.identifiers.UsernameSlugRegex
+import com.wasmo.identifiers.isUsernameValid
 import com.wasmo.support.tokens.toChallengeCodeOrNull
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -154,7 +154,7 @@ class SignUpPresenter(
           it.copy(
             newAccountWithUsername = usernameModel.copy(
               username = event.username,
-              canSubmit = UsernameSlugRegex.matches(event.username),
+              canSubmit = isUsernameValid(event.username),
             ),
           )
         }

--- a/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
+++ b/os/server/db/src/jvmMain/kotlin/com/wasmo/db/usernames/UsernameQueries.kt
@@ -25,18 +25,21 @@ suspend fun insertUsername(
     INSERT INTO Username(
       created_at,
       account_id,
-      username
+      username,
+      normalized_value
     )
     VALUES (
       $1,
       $2,
-      $3
+      $3,
+      $4
     )
     """,
   ) {
     bindInstant(0, createdAt)
     bindAccountId(1, accountId)
     bindString(2, usernameSlug.value)
+    bindString(3, usernameSlug.normalizedValue)
   }
 }
 
@@ -104,6 +107,7 @@ suspend fun findUsernameOrNull(
       created_at,
       account_id,
       username,
+      normalized_value,
       deleted_at
     FROM Username
     WHERE account_id = $1 AND deleted_at IS NULL
@@ -136,6 +140,7 @@ suspend fun selectLinkedUsernameOrNullAllowDeleted(
       created_at,
       account_id,
       username,
+      normalized_value,
       deleted_at
     FROM Username
     WHERE username = $1
@@ -160,6 +165,7 @@ suspend fun findUsernamesThatCanSignIn(
       created_at,
       account_id,
       username,
+      normalized_value,
       deleted_at
     FROM Username
     WHERE deleted_at IS NULL
@@ -174,11 +180,21 @@ suspend fun findUsernamesThatCanSignIn(
   }
 }
 
-
-private fun SqlRow.getUsername() = DbUsername(
-  id = getUsernameId(0),
-  createdAt = getInstant(1)!!,
-  accountId = getAccountId(2),
-  username = UsernameSlug(getString(3)!!),
-  deletedAt = getInstant(4)
-)
+private fun SqlRow.getUsername(): DbUsername =
+  DbUsername(
+    id = getUsernameId(0),
+    createdAt = getInstant(1)!!,
+    accountId = getAccountId(2),
+    username = UsernameSlug(getString(3)!!),
+    deletedAt = getInstant(5)
+  ).also {
+    val normalizedValue = getString(4)
+    check(normalizedValue == it.username.normalizedValue) {
+      // This indicates a programming error on the Wasmo side.
+      // It means that our normalization algorithm has changed and that we ought to create a DB
+      // migration step that updates the normalized_values of the usernames in the DB
+      // (perhapsy by copying them to a new table and deleting the old one).
+      "DB persistent state is inconsistent: Username '${it.username.value}' " +
+        "normalizes to '${it.username.normalizedValue}', but DB has '$normalizedValue'"
+    }
+  }

--- a/os/server/db/src/jvmMain/resources/migrations/v4__Username.sql
+++ b/os/server/db/src/jvmMain/resources/migrations/v4__Username.sql
@@ -3,12 +3,13 @@ CREATE TABLE Username (
   -- Subject to clock limitations (e.g. may not be strictly increasing).
   created_at TIMESTAMPTZ NOT NULL,
   account_id BIGINT NOT NULL,
-  username VARCHAR(255) UNIQUE NOT NULL,
+  username VARCHAR(255) NOT NULL,
+  -- normalized value is what needs to be unique because it's used for equals / hashCode purposes
+  normalized_value VARCHAR(255) UNIQUE NOT NULL,
   -- When this username was deleted. Modifying code should ensure that if this has been replaced
   -- with another username, then that username's created_at timestamp will match this and its
   -- account_id will match ours.
   deleted_at TIMESTAMPTZ DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX UsernameUsername ON Username(username);
 CREATE UNIQUE INDEX UsernameAccountIdNotDeleted ON Username(account_id) WHERE deleted_at IS NULL;


### PR DESCRIPTION
Uppercase characters and punctuation are preserved, but ignored for concerns of uniqueness constraint, `equals`, and `hashCode`. This is done by deriving a `normalized value` on top of which these concerns are expressed.

To guarantee consistency between Kotlin and PostgreSQL concepts of equality, the normalized value is stored explicitly in a DB column, rather than using a [ICU Custom Collation](https://www.postgresql.org/docs/current/collation.html#ICU-CUSTOM-COLLATIONS). This means:

 - If we ever change our normalization algorithm, we'll need a DB migration step to update the stored normalized values; for now, we check for consistency at read time and throw SqlException upon violation.
 - Developers need to wipe their database to adopt the latest schema.

### Properties of the new design

 - These characters count as punctuation: `-`, `_`, `.`.
 - The normalized value is converted to lowercase using the root Locale and punctuation is stripped, i.e. the following usernames are all equal: `johndoe`, `John.Doe`, `john-doe`, `john_doe`, `j.o.h.n_d-o-e`.
 - Punctuation may not appear in the first or last position. Thus, the normalized form will never be empty.
 - Not more than one punctuation character may appear in a row.
 - Sequences of digits are still allowed, except in the first position.

### Notes

 - No other slugs (AppSlug, ComputerSlug, DatabaseSlug) allow these characters. Should any of them?
 - I also changed length 1-15 -> 3-20 characters (before normalization, which implies 2-20 characters after normalization).
 - I added logic to preseve the case / punctuation of the value the user potentially entered at the login prompt, but right now this logic isn't used because our UI only allows the user to select their username from already-canonical list.


### Screenshot
<img width="1361" height="528" alt="Screenshot From 2026-05-21 01-01-14" src="https://github.com/user-attachments/assets/8faaa39b-38ea-4340-870d-5735c0de96bc" />
