### PR TITLE
Use same version of node in gradle unconditionally

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,15 +97,15 @@ allprojects {
   }
 
   // Don't download Node in CI, it's available in our Docker image.
-  if (project.findProperty("wasmo.build.environment") == "ci") {
-    project.plugins.withType<NodeJsPlugin> {
-      project.the<NodeJsEnvSpec>().apply {
-        command.set("/usr/local/bin/node")
+  project.plugins.withType<NodeJsPlugin> {
+    project.the<NodeJsEnvSpec>().apply {
+      if (project.findProperty("wasmo.build.environment") == "ci") {
         download = false
-
-        // Consistent with wasmo-build/ci/Dockerfile
-        version = "26.1.0"
+        command.set("/usr/local/bin/node")
       }
+
+      // Consistent with wasmo-build/ci/Dockerfile
+      version = "26.1.0"
     }
   }
 }


### PR DESCRIPTION
Trying to get a working build locally.

This doesn't fix it (`run ci-build \gradle jvm Test` still isn't find an npm binary, and looking at this change it seems like it should be in the `ci` environment but isn't) , but it seems like the right thing to do anyway!