### PR TITLE
Fix compilation of `./gradlew os:distributions:homelab:run`

### DIFF
--- a/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/PostgresqlClient.kt
+++ b/os/server/sql/real/src/jvmMain/kotlin/com/wasmo/sql/PostgresqlClient.kt
@@ -1,5 +1,8 @@
 package com.wasmo.sql
 
+import com.wasmo.identifiers.OsScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import io.vertx.pgclient.PgBuilder
 import io.vertx.pgclient.PgConnectOptions
 import io.vertx.pgclient.SslMode
@@ -34,6 +37,8 @@ class PostgresqlClient(
     pool.close()
   }
 
+  @Inject
+  @SingleIn(OsScope::class)
   class Factory {
     fun connect(
       address: PostgresqlAddress,


### PR DESCRIPTION
Give RealOsDatabaseInitializer's clientFactory argument a default value, since there's really only one reasonable value (?).

As of commit 5afbf8a71415da2860ad52a9525fcb23ebb54897, the command failed. Perhaps this exact command is now obsolete, because of Docker?