### PR TITLE
Allow signing up *or* in by typing the username.

### DIFF
--- a/identifiers/src/commonMain/kotlin/com/wasmo/identifiers/UsernameSlug.kt
+++ b/identifiers/src/commonMain/kotlin/com/wasmo/identifiers/UsernameSlug.kt
@@ -18,7 +18,11 @@ value class UsernameSlug(val value: String) {
 
   // DB required normalizedValue to be UNIQUE among usernames
   val normalizedValue: String
-    get() = value.replace(Regex("[._-]"), "").lowercase()
+    get() = normalize(value)
+
+  companion object {
+    fun normalize(value: String): String = value.replace(Regex("[._-]"), "").lowercase()
+  }
 }
 
 /**

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/NewOrExistingAccountWithUsernameScreen.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/NewOrExistingAccountWithUsernameScreen.kt
@@ -5,13 +5,14 @@ import com.wasmo.compose.Button
 import com.wasmo.compose.Column
 import com.wasmo.compose.PageLayout
 import com.wasmo.compose.TextField
+import com.wasmo.identifiers.UsernameSlug
 import org.jetbrains.compose.web.attributes.AttrsScope
 import org.jetbrains.compose.web.dom.H1
 import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLDivElement
 
 @Composable
-fun NewAccountWithUsernameScreen(
+fun NewOrExistingAccountWithUsernameScreen(
   attrs: AttrsScope<HTMLDivElement>.() -> Unit = {},
   eventListener: (SignUpEvent) -> Unit,
   username: String,
@@ -19,6 +20,7 @@ fun NewAccountWithUsernameScreen(
   disabled: Boolean,
   canSubmit: Boolean,
   busy: Boolean,
+  existingUsernameToSignInAs: UsernameSlug? = null,
 ) {
   PageLayout(
     attrs = attrs,
@@ -50,11 +52,16 @@ fun NewAccountWithUsernameScreen(
         disabled = !canSubmit || disabled,
         attrs = {
           onClick {
-            eventListener(SignUpEvent.ClickSignUpWithUsername)
+            val event = if (existingUsernameToSignInAs == null) {
+              SignUpEvent.ClickSignUpWithUsername
+            } else {
+              SignUpEvent.ClickUsername(existingUsernameToSignInAs)
+            }
+            eventListener(event)
           }
         },
       ) {
-        Text("Sign Up")
+        Text(if (existingUsernameToSignInAs == null) "Sign Up" else "Sign In as ${existingUsernameToSignInAs.value}" )
       }
     }
   }

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpModel.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpModel.kt
@@ -6,7 +6,7 @@ data class SignUpModel(
   val inFlightCalls: Int = 0,
   val enterChallengeCode: EnterChallengeCodeModel? = null,
   val enterEmailAddress: EnterEmailAddressModel? = null,
-  val newAccountWithUsername: NewAccountWithUsernameModel? = null,
+  val newOrExistingAccountWithUsername: NewOrExistingAccountWithUsernameModel? = null,
   val selectUsernameToSignIn: SelectUsernameToSignInModel? = null,
 )
 
@@ -17,11 +17,15 @@ data class SelectUsernameToSignInModel(
   val canSubmit: Boolean = false,
 )
 
-/** Enter a new username to sign-up and simultaneously sign-in with that username. */
-data class NewAccountWithUsernameModel(
+/** Enter a new username to sign-up and simultaneously sign-in with that username, or sign-in as an existing username. */
+data class NewOrExistingAccountWithUsernameModel(
   val username: String = "",
   val usernameHelperText: String = "",
   val canSubmit: Boolean = false,
+  // An existing username to sign-in as. For example, if user "Jesse.123" already exists
+  // and the user has typed username="jesse123", then rather than sign-up as "jesse123",
+  // we offer them to sign-in as "Jesse.123".
+  val existingUsernameToSignInAs: UsernameSlug? = null,
 )
 
 /** Enter an email address. You'll be emailed a challenge code to confirm. */

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpPresenter.kt
@@ -27,6 +27,9 @@ class SignUpPresenter(
   private val accountDataService: AccountDataService,
   signInSnapshot: SignInSnapshot?,
 ) : Presenter<SignUpModel, SignUpEvent> {
+  private val existingUsernames = signInSnapshot?.usernameOptions ?: listOf()
+  private val normalizedToExistingUsername = existingUsernames.associateBy { it.normalizedValue }
+
   private val mutableModel = MutableStateFlow(
     // TODO: Make SignInSnapshot responsible for all sign-in options, not only username.
     if (signInSnapshot == null) {
@@ -150,11 +153,17 @@ class SignUpPresenter(
 
       is SignUpEvent.EditUsername -> {
         mutableModel.update {
-          val usernameModel = it.newAccountWithUsername ?: return // Race.
+          val usernameModel = it.newOrExistingAccountWithUsername ?: return // Race.
+          val usernameString = event.username
+          val isValid = isUsernameValid(usernameString)
+          val signInUsername: UsernameSlug? = if (isValid) normalizedToExistingUsername[UsernameSlug.normalize(usernameString)] else null
+          val isSignIn = signInUsername != null
           it.copy(
-            newAccountWithUsername = usernameModel.copy(
+            newOrExistingAccountWithUsername = usernameModel.copy(
               username = event.username,
-              canSubmit = isUsernameValid(event.username),
+              canSubmit = isValid,
+              existingUsernameToSignInAs = signInUsername,
+              usernameHelperText = if (isSignIn) "${signInUsername.value} exists" else ""
             ),
           )
         }
@@ -162,7 +171,7 @@ class SignUpPresenter(
 
       SignUpEvent.ClickSignUpWithUsername -> {
         callServer { state ->
-          val usernameModel = state.newAccountWithUsername ?: return@callServer // Race.
+          val usernameModel = state.newOrExistingAccountWithUsername ?: return@callServer // Race.
           val response = accountDataService.createUsername(UsernameSlug(usernameModel.username))
           when (response.decision) {
             CreateUsernameDecision.Success -> {
@@ -198,7 +207,7 @@ class SignUpPresenter(
       SignUpEvent.ClickNewAccount -> {
         mutableModel.update { state ->
           state.copy(
-            newAccountWithUsername = NewAccountWithUsernameModel()
+            newOrExistingAccountWithUsername = NewOrExistingAccountWithUsernameModel()
           )
         }
       }

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpUi.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/signup/SignUpUi.kt
@@ -50,14 +50,15 @@ class SignUpUi(
       return
     }
 
-    val newAccountWithUsernameModel = state.newAccountWithUsername
-    if (newAccountWithUsernameModel != null) {
-      NewAccountWithUsernameScreen(
+    val newOrExistingAccountWithUsernameModel = state.newOrExistingAccountWithUsername
+    if (newOrExistingAccountWithUsernameModel != null) {
+      NewOrExistingAccountWithUsernameScreen(
         attrs = attrs,
         eventListener = presenter::onEvent,
-        username = newAccountWithUsernameModel.username,
-        usernameHelperText = newAccountWithUsernameModel.usernameHelperText,
-        canSubmit = newAccountWithUsernameModel.canSubmit,
+        username = newOrExistingAccountWithUsernameModel.username,
+        usernameHelperText = newOrExistingAccountWithUsernameModel.usernameHelperText,
+        existingUsernameToSignInAs = newOrExistingAccountWithUsernameModel.existingUsernameToSignInAs,
+        canSubmit = newOrExistingAccountWithUsernameModel.canSubmit,
         disabled = state.inFlightCalls > 0,
         busy = state.inFlightCalls > 0,
       )

--- a/os/client/app/src/jsTest/kotlin/com/wasmo/client/app/signup/SignUpTest.kt
+++ b/os/client/app/src/jsTest/kotlin/com/wasmo/client/app/signup/SignUpTest.kt
@@ -84,7 +84,7 @@ class SignUpTest {
       darkMode = darkMode,
       background = "var(--pico-background-color)",
     ) {
-      NewAccountWithUsernameScreen(
+      NewOrExistingAccountWithUsernameScreen(
         attrs = {
           classes("FillWidthHeight")
         },


### PR DESCRIPTION
When the user enters a new username to sign-up with, we now recognize when that username already exists (as of when the page was loaded, so may be slightly out of date).

When this happens, we offer to sign-in via the existing username, in the spelling from when that username was registered (not the spelling that the user entered now):

 - The button text changes Sign Up -> Sign In as <username>
 - The event produced by clicking the button is `ClickUsername` rather than `ClickSignUpWithUsername`.
   - As an alternative, I considered renaming to `ClickSignUpOrInWithUsername` and giving it a `UsernameSlug?` parameter, but  I reused the existing event since `SignUpPresenter` should handle it identically.

"Already exists" here is based on the normalized username - if the user enters `jesse-123`, we offer them to sign in as `Jesse.123` (assuming that account exists), since both normalize to `jesse123`. This client-side UI matches current server behavior (spelling from when the account was created wins).

In the future, we may change server and client behavior with regards to whether to sign-in using the existing vs. the new spelling.

## Screenshot

<img width="987" height="327" alt="image" src="https://github.com/user-attachments/assets/50db33a6-1a3d-463b-8400-250cc015b292" />
