### PR TITLE
Add missing param for local ci execution

### DIFF
--- a/docs/code/buildkite_ci.md
+++ b/docs/code/buildkite_ci.md
@@ -52,7 +52,7 @@ $ cd ../..
 $ docker-compose \
   -f .buildkite/docker-compose.yml \
   run ci-build \
-  gradle :jvmTest
+  gradle :jvmTest -Pwasmo.build.environment=ci
 ```
 
 Consider keeping a separate clone of the Wasmo repo for doing Linux x64 builds. Our Gradle plugins


### PR DESCRIPTION
I suppose the other option is to just get rid of this completely