### PR TITLE
Successfully decode all WASI .wit files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/pico"]
 	path = submodules/pico
 	url = https://github.com/picocss/pico.git
+[submodule "submodules/WASI"]
+	path = submodules/WASI
+	url = https://github.com/WebAssembly/WASI.git

--- a/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Declarations.kt
+++ b/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Declarations.kt
@@ -173,10 +173,10 @@ data class Parameter(
   val type: TypeName? = null,
 ) {
   companion object {
-    operator fun invoke(location: Location, name: String, typeName: String) = Parameter(
+    operator fun invoke(location: Location, name: String, type: String) = Parameter(
       location = location,
       name = Identifier(name),
-      type = TypeName(typeName),
+      type = TypeName(type),
     )
   }
 }

--- a/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Identifiers.kt
+++ b/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Identifiers.kt
@@ -5,10 +5,7 @@ data class UsePath(
   val packageNames: List<Identifier> = listOf(),
   val name: Identifier,
   val version: SemVer? = null,
-) {
-  val isNameOnly: Boolean
-    get() = namespaces.isEmpty() && packageNames.isEmpty() && version == null
-}
+)
 
 @JvmInline
 value class Identifier(

--- a/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Support.kt
+++ b/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/Support.kt
@@ -1,6 +1,0 @@
-package com.wasmo.support.wit
-
-sealed interface Either<A, B> {
-  data class A<A, B>(val value: A) : Either<A, B>
-  data class B<A, B>(val value: B) : Either<A, B>
-}

--- a/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/WitReader.kt
+++ b/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/WitReader.kt
@@ -553,6 +553,9 @@ class WitReader private constructor(
       )
     }
 
+    source.skipWhitespace()
+    source.readLiteral(';')
+
     return Use(
       documentation = documentation,
       gate = gate,
@@ -645,21 +648,7 @@ class WitReader private constructor(
    * ```
    */
   private fun readParameterList(): List<Parameter> {
-    source.readLiteral('(')
-
-    val result = mutableListOf<Parameter>()
-    var first = true
-    while (true) {
-      source.skipWhitespace()
-      if (source.tryReadLiteral(')')) break
-
-      if (first) {
-        first = false
-      } else {
-        source.readLiteral(',')
-      }
-
-      source.skipWhitespace()
+    return source.readCommaSeparatedList(minSize = 0, '(', ')') {
       val location = source.location
       val parameterName = source.readIdentifier()
 
@@ -669,14 +658,12 @@ class WitReader private constructor(
       source.skipWhitespace()
       val parameterType = source.readTypeName()
 
-      result += Parameter(
+      Parameter(
         location = location,
         name = parameterName,
         type = parameterType,
       )
     }
-
-    return result
   }
 
   /**

--- a/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/WitStructureReader.kt
+++ b/support/wit/src/jvmMain/kotlin/com/wasmo/support/wit/WitStructureReader.kt
@@ -77,8 +77,26 @@ internal class WitStructureReader(
     documentation.appendRange(chars, startIndex, endIndex)
   }
 
-  fun readIdentifier(): Identifier =
-    Identifier(readToken("word", Char::isWordCharacter))
+  fun readIdentifier(): Identifier {
+    checkWit(!exhausted) {
+      "expected an identifier"
+    }
+
+    val wordStart = when (chars[pos]) {
+      '%' -> pos + 1
+      else -> pos
+    }
+
+    val end = chars.indexOfNextNonMatch(wordStart, Char::isWordCharacter)
+    checkWit(wordStart < end) {
+      "expected an identifier"
+    }
+
+    val result = String(chars, pos, end - pos)
+    pos = end
+
+    return Identifier(result)
+  }
 
   fun readSemVer(): SemVer {
     var end = chars.indexOfNextNonMatch(pos, Char::isSemverCharacter)
@@ -433,27 +451,30 @@ internal class WitStructureReader(
   }
 
   /**
-   * Reads a list of 1 or more items, wrapped in '{' curly braces '}' and separated by commas.
-   * Trailing commas are okay.
+   * Reads a list of [minSize] or more items, wrapped in braces and separated by commas. Trailing
+   * commas are okay.
    */
-  fun <T> readCommaSeparatedList(readItem: () -> T): List<T> {
+  fun <T> readCommaSeparatedList(
+    minSize: Int = 1,
+    open: Char = '{',
+    close: Char = '}',
+    readItem: () -> T
+  ): List<T> {
     val result = mutableListOf<T>()
 
     skipWhitespace()
-    readLiteral('{')
+    readLiteral(open)
     skipWhitespace()
-    while (true) {
+    while (result.size < minSize || !tryReadLiteral(close)) {
       result += readItem()
 
       skipWhitespace()
-      if (tryReadLiteral(',')) {
-        skipWhitespace()
-        if (tryReadLiteral('}')) break // Trailing comma.
-        continue
+      if (!tryReadLiteral(',')) {
+        readLiteral(close)
+        break
       }
 
-      readLiteral('}')
-      break
+      skipWhitespace()
     }
 
     return result

--- a/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/ReadAllWasiFilesTest.kt
+++ b/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/ReadAllWasiFilesTest.kt
@@ -1,0 +1,40 @@
+package com.wasmo.support.wit
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.test.fail
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+class ReadAllWasiFilesTest {
+  private val fileSystem = FileSystem.SYSTEM
+  private val wasiProposals = "../../submodules/WASI/proposals".toPath()
+
+  @Test
+  fun test() {
+    var witFileCount = 0
+    for (path in fileSystem.listRecursively(wasiProposals)) {
+      if (!path.name.endsWith(".wit")) continue
+
+      val witContent = fileSystem.read(path) {
+        readUtf8()
+      }
+
+      val witReader = WitReader(witContent)
+      try {
+        witReader.read()
+      } catch (e: WitException) {
+        fail("decoding $path failed at ${e.location}: ${e.issue}")
+      }
+
+      witFileCount++
+    }
+
+    // Confirm we successfully decoded a reasonable number of files. If this fails after updating
+    // the WASI submodule, it's probably correct to change this value.
+    //
+    // But don't change it to 0, that means our paths are out of date.
+    assertThat(witFileCount).isEqualTo(57)
+  }
+}

--- a/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/WitReaderTest.kt
+++ b/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/WitReaderTest.kt
@@ -385,6 +385,42 @@ class WitReaderTest {
   }
 
   @Test
+  fun `function parameters trailing commas`() {
+    val wit = """
+      |interface monotonic-clock {
+      |  subscribe-instant: func(
+      |    when: instant,
+      |  ) -> pollable;
+      |}
+      """.trimMargin()
+    val witReader = WitReader(wit)
+    assertThat(witReader.read()).isEqualTo(
+      WitFile(
+        declarations = listOf(
+          Interface(
+            location = Location(1, 1),
+            name = TypeName("monotonic-clock"),
+            declarations = listOf(
+              Function(
+                location = Location(2, 3),
+                name = Identifier("subscribe-instant"),
+                parameters = listOf(
+                  Parameter(
+                    location = Location(3, 5),
+                    name = "when",
+                    type = "instant",
+                  ),
+                ),
+                returnType = TypeName("pollable"),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun `resource documentation and gates`() {
     val wit = """
       |interface db {
@@ -756,10 +792,10 @@ class WitReaderTest {
       |interface db {
       |  /// Four values.
       |  @since(version = 1.0)
-      |  use an-interface.{a, list, of, names}
+      |  use an-interface.{a, list, of, names};
       |  /// One aliased value.
       |  @since(version = 2.0)
-      |  use my:dependency/the-interface@3.0.{more, names as foo}
+      |  use my:dependency/the-interface@3.0.{more, names as foo};
       |}
       """.trimMargin()
     val witReader = WitReader(wit)

--- a/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/WitStructureReaderTest.kt
+++ b/support/wit/src/jvmTest/kotlin/com/wasmo/support/wit/WitStructureReaderTest.kt
@@ -1,7 +1,6 @@
 package com.wasmo.support.wit
 
 import assertk.assertThat
-import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
@@ -293,35 +292,44 @@ class WitStructureReaderTest {
 
   @Test
   fun `readIdentifier success`() {
-    val reader = WitStructureReader(
-      """
-      |a abc def-ghi-xyz DEF-GHI-XYZ abc1234-ABC1234
-      """.trimMargin(),
-    )
-    assertThat(reader.readIdentifier()).isEqualTo(Identifier("a"))
-    reader.skipWhitespace()
-    assertThat(reader.readIdentifier()).isEqualTo(Identifier("abc"))
-    reader.skipWhitespace()
-    assertThat(reader.readIdentifier()).isEqualTo(Identifier("def-ghi-xyz"))
-    reader.skipWhitespace()
-    assertThat(reader.readIdentifier()).isEqualTo(Identifier("DEF-GHI-XYZ"))
-    reader.skipWhitespace()
-    assertThat(reader.readIdentifier()).isEqualTo(Identifier("abc1234-ABC1234"))
+    assertThat("a".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("a ".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("a,".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("a)".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("a}".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("a:".parseIdentifier()).isEqualTo(Identifier("a"))
+    assertThat("abc".parseIdentifier()).isEqualTo(Identifier("abc"))
+    assertThat("abc ".parseIdentifier()).isEqualTo(Identifier("abc"))
+    assertThat("def-ghi-xyz ".parseIdentifier()).isEqualTo(Identifier("def-ghi-xyz"))
+    assertThat("DEF-GHI-XYZ ".parseIdentifier()).isEqualTo(Identifier("DEF-GHI-XYZ"))
+    assertThat("abc1234-ABC1234 ".parseIdentifier()).isEqualTo(Identifier("abc1234-ABC1234"))
+    assertThat("%a".parseIdentifier()).isEqualTo(Identifier("%a"))
+    assertThat("%abc".parseIdentifier()).isEqualTo(Identifier("%abc"))
+    assertThat("%abc%d".parseIdentifier()).isEqualTo(Identifier("%abc"))
   }
 
   @Test
   fun `readIdentifier crash`() {
     assertFailsWith<WitException> {
-      WitStructureReader(" ").readIdentifier()
+      " ".parseIdentifier()
     }
     assertFailsWith<WitException> {
-      WitStructureReader("_").readIdentifier()
+      "_".parseIdentifier()
     }
     assertFailsWith<WitException> {
-      WitStructureReader("()").readIdentifier()
+      "()".parseIdentifier()
     }
     assertFailsWith<WitException> {
-      WitStructureReader("").readIdentifier()
+      "".parseIdentifier()
+    }
+    assertFailsWith<WitException> {
+      "%%".parseIdentifier()
+    }
+    assertFailsWith<WitException> {
+      "%".parseIdentifier()
+    }
+    assertFailsWith<WitException> {
+      "% ".parseIdentifier()
     }
   }
 
@@ -389,7 +397,7 @@ class WitStructureReaderTest {
     val e = assertFailsWith<WitException> {
       "a:".parsePackageName()
     }
-    assertThat(e.issue).isEqualTo("expected a word character")
+    assertThat(e.issue).isEqualTo("expected an identifier")
   }
 
   @Test
@@ -397,7 +405,7 @@ class WitStructureReaderTest {
     val e = assertFailsWith<WitException> {
       ":".parsePackageName()
     }
-    assertThat(e.issue).isEqualTo("expected a word character")
+    assertThat(e.issue).isEqualTo("expected an identifier")
   }
 
   @Test
@@ -584,6 +592,9 @@ class WitStructureReaderTest {
       "borrow<string, string>".parseTypeName()
     }
   }
+
+  private fun String.parseIdentifier(): Identifier =
+    WitStructureReader(this).readIdentifier()
 
   private fun String.parsePackageName(): PackageName =
     WitStructureReader(this).readPackageName()


### PR DESCRIPTION
This encountered a few problems:

 - use statements need a trailing ';'
 - parameter lists may have a trailing ','
 - identifiers may start with '%'

Also add the WASI repo as a git submodule to support running this test in CI. This isn't a particularly good precedent, but eventually we'll eject support/wit from the OS repo.