### PR TITLE
WIP: experiment with Chromium in Docker for CI

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       POSTGRES_PASSWORD: password
 
   ci-build:
-    image: wasmo/ci@sha256:fffcd3e123de5ca944aa7d1f0551d371991f5b8cb8deb41a484741ce0eeb8e48
+    image: wasmo/ci
     working_dir: /workdir
     volumes:
       - ..:/workdir

--- a/docs/code/buildkite_ci.md
+++ b/docs/code/buildkite_ci.md
@@ -39,8 +39,7 @@ Local Execution
 Rebuild the container if necessary.
 
 ```bash
-$ cd ../..
-$ cd wasmo-build/ci
+$ cd ../../wasmo-build/ci
 $ docker build -t wasmo/ci .
 $ docker push wasmo/ci
 ```
@@ -52,7 +51,7 @@ $ cd ../..
 $ docker-compose \
   -f .buildkite/docker-compose.yml \
   run ci-build \
-  gradle :jvmTest -Pwasmo.build.environment=ci
+  gradle jvmTest jsTest -Pwasmo.build.environment=ci
 ```
 
 Consider keeping a separate clone of the Wasmo repo for doing Linux x64 builds. Our Gradle plugins

--- a/wasmo-build/ci/Dockerfile
+++ b/wasmo-build/ci/Dockerfile
@@ -1,5 +1,11 @@
 # Wasmo CI
 #
+# It's got:
+#   - OpenJDK
+#   - Gradle
+#   - NodeJS (for jsNodeTest)
+#   - Chromium (for jsBrowserTest)
+#
 # This file includes code from Gradle's Dockerfile
 # Copyright 2025 Gradle Inc.
 # https://www.apache.org/licenses/LICENSE-2.0
@@ -21,8 +27,21 @@ RUN set -o errexit -o nounset \
       tar \
       xz \
       \
+    && echo "Installing Chromium with apk" \
+    && apk add --no-cache \
+      chromium \
+      dbus \
+      dbus-x11 \
+      nss \
+      ca-certificates \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ttf-freefont \
+      \
     && echo "Testing utilities" \
     && which awk \
+    && which chromium \
     && which curl \
     && which cut \
     && which grep \
@@ -32,6 +51,12 @@ RUN set -o errexit -o nounset \
     && which tar \
     && which tr \
     && which unzip
+
+COPY ./wasmo-ci /wasmo-ci
+RUN chmod o+rwx /wasmo-ci/bin/*
+
+# Help Karma find Chromium for Kotlin/JS tests.
+ENV CHROME_BIN="/wasmo-ci/bin/chromium"
 
 # Install Gradle.
 ENV GRADLE_VERSION=9.5.1
@@ -110,4 +135,12 @@ RUN --mount=type=cache,target=/downloads,rw \
     && npm --version \
     && rm -rf /tmp/*
 
+RUN mkdir -p /run/dbus \
+    && chown gradle:gradle /run/dbus
+
+USER gradle
+
+ENV DBUS_SESSION_BUS_ADDRESS autolaunch:
+
+ENTRYPOINT ["/wasmo-ci/bin/entrypoint"]
 CMD ["gradle"]

--- a/wasmo-build/ci/wasmo-ci/bin/chromium
+++ b/wasmo-build/ci/wasmo-ci/bin/chromium
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Use --headless to avoid these errors:
+#   Failed to connect to the bus:
+#     Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+# Use --no-sandbox to avoid these errors:
+#   Failed to move to new namespace:
+#     PID namespaces supported,
+#     Network namespace supported, but failed: errno = Permission denied.
+# https://chromium.googlesource.com/chromium/src/+/HEAD/docs/design/sandbox.md
+/usr/bin/chromium --headless --no-sandbox "$*"

--- a/wasmo-build/ci/wasmo-ci/bin/entrypoint
+++ b/wasmo-build/ci/wasmo-ci/bin/entrypoint
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Chromium requires dbus to avoid this error:
+#   Failed to connect to the bus:
+#   Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+# dbus-daemon --system
+
+$*


### PR DESCRIPTION
I was unsuccessful, and I'm going to give up on this for now. I suspect the least gross solution is to build on the Puppeteer project's Docker image, possibly building upon the Puppeteer Docker image.

https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile