### PR TITLE
Split up TypeReference collection code into two sequences

### DIFF
--- a/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/Identifiers.kt
+++ b/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/Identifiers.kt
@@ -1,5 +1,30 @@
 package com.wasmo.support.wit
 
+import okio.Path
+
+/**
+ * A location within a `.wit` package. The package name and interface name define a scope to resolve
+ * relative references to types.
+ *
+ * Within a `use` or `include` declaration, the package name and interface name will be the target
+ * scope to search, which may be in a different path. For example, the `pollable` symbol will be
+ * resolved in the `wasi:io@0.2.12` package.
+ *
+ * ```wit
+ * package wasi:clocks@0.2.12;
+ *
+ * interface monotonic-clock {
+ *   use wasi:io/poll@0.2.12.{pollable};
+ * }
+ * ```
+ */
+data class Location(
+  val path: Path,
+  val offset: Offset,
+  val packageName: PackageName,
+  val interfaceName: Identifier?,
+)
+
 /**
  * This is a package name plus an interface name, or just an interface name. The encoded form always
  * puts the version at the end of the entire string.

--- a/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/Traversal.kt
+++ b/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/Traversal.kt
@@ -1,0 +1,109 @@
+package com.wasmo.support.wit
+
+/**
+ * Returns a sequence that traverses the declarations of this package.
+ */
+val WitPackage.depthFirstDeclarations: Sequence<Pair<Location, Declaration>>
+  get() = sequence {
+    for ((path, witFile) in files) {
+      for (declaration in witFile.declarations) {
+        this.depthFirstDeclarations(
+          location = Location(
+            offset = declaration.offset,
+            path = path,
+            packageName = packageName,
+            interfaceName = null,
+          ),
+          subject = declaration,
+        )
+      }
+    }
+  }
+
+suspend fun SequenceScope<Pair<Location, Declaration>>.depthFirstDeclarations(
+  location: Location,
+  subject: Declaration,
+) {
+  var subjectLocation = location.copy(
+    offset = subject.offset,
+  )
+  when (subject) {
+    is Include -> {
+      subjectLocation = subjectLocation.copy(
+        packageName = subject.path.packageName ?: location.packageName,
+        interfaceName = subject.path.name,
+      )
+      yield(subjectLocation to subject)
+    }
+
+    is Interface -> {
+      subjectLocation = subjectLocation.copy(
+        interfaceName = subject.name,
+      )
+      yield(subjectLocation to subject)
+      for (declaration in subject.declarations) {
+        depthFirstDeclarations(subjectLocation, declaration)
+      }
+    }
+
+    is Package -> {
+      subjectLocation = subjectLocation.copy(
+        packageName = subject.name ?: location.packageName,
+      )
+      yield(subjectLocation to subject)
+      for (declaration in subject.declarations) {
+        depthFirstDeclarations(subjectLocation, declaration)
+      }
+    }
+
+    is Record -> {
+      yield(subjectLocation to subject)
+      for (field in subject.fields) {
+        depthFirstDeclarations(subjectLocation, field)
+      }
+    }
+
+    is Resource -> {
+      yield(subjectLocation to subject)
+      for (function in subject.functions) {
+        depthFirstDeclarations(subjectLocation, function)
+      }
+    }
+
+    is Variant -> {
+      yield(subjectLocation to subject)
+      for (case in subject.cases) {
+        depthFirstDeclarations(subjectLocation, case)
+      }
+    }
+
+    is Use -> {
+      subjectLocation = subjectLocation.copy(
+        packageName = subject.path.packageName ?: location.packageName,
+        interfaceName = subject.path.name,
+      )
+      yield(subjectLocation to subject)
+    }
+
+    is World -> {
+      subjectLocation = subjectLocation.copy(
+        interfaceName = subject.name,
+      )
+      yield(subjectLocation to subject)
+      for (export in subject.declarations) {
+        depthFirstDeclarations(subjectLocation, export)
+      }
+      for (export in subject.imports) {
+        depthFirstDeclarations(subjectLocation, export)
+      }
+      for (export in subject.exports) {
+        depthFirstDeclarations(subjectLocation, export)
+      }
+    }
+
+    else -> {
+      yield(subjectLocation to subject)
+    }
+  }
+}
+

--- a/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/TypeReference.kt
+++ b/support/wit/wit-core/src/jvmMain/kotlin/com/wasmo/support/wit/TypeReference.kt
@@ -1,6 +1,15 @@
 package com.wasmo.support.wit
 
-import okio.Path
+/**
+ * A reference to a type expected to be found elsewhere.
+ *
+ * The [location] describes where to look, which is not necessarily where the type was encountered.
+ * For example, a [Use] may specify which package to look in for a referenced type.
+ */
+data class TypeReference(
+  val location: Location,
+  val typeName: TypeName,
+)
 
 /**
  * Returns all type references in this package.
@@ -10,111 +19,38 @@ import okio.Path
  * declarations don't otherwise impact source code.
  */
 fun WitPackage.typeReferences(): Sequence<TypeReference> = sequence {
-  for ((path, witFile) in files) {
-    for (declaration in witFile.declarations) {
-      TypeReferenceScanner(
-        path = path,
-        packageName = packageName,
-        subject = declaration,
-      ).scan()
-    }
-  }
-}
-
-/**
- * A reference to a type expected to be found elsewhere.
- *
- * The [packageName] and [interfaceName] describe where to look, which is not necessarily where the
- * type was encountered. For example, a [Use] may specify which package to look in for a referenced
- * type.
- */
-data class TypeReference(
-  val path: Path,
-  val offset: Offset,
-  val packageName: PackageName,
-  val interfaceName: Identifier?,
-  val typeName: TypeName,
-)
-
-/** Does a depth-first traversal of [subject], looking for [TypeName] instances. */
-private class TypeReferenceScanner(
-  private val path: Path,
-  private val packageName: PackageName,
-  private val interfaceName: Identifier? = null,
-  private val subject: Declaration,
-) {
-  context(sequence: SequenceScope<TypeReference>)
-  suspend fun scan() {
+  for ((location, subject) in depthFirstDeclarations) {
     when (subject) {
-      is Case -> yield(subject.type)
-      is Field -> yield(subject.type)
+      is Case -> {
+        if (subject.type != null) {
+          yield(TypeReference(location, subject.type))
+        }
+      }
+
+      is Field -> yield(TypeReference(location, subject.type))
       is Function -> {
         for (parameter in subject.parameters) {
-          yield(parameter.type)
+          yield(TypeReference(location, parameter.type))
         }
-        yield(subject.returnType)
+        if (subject.returnType != null) {
+          yield(TypeReference(location, subject.returnType))
+        }
       }
 
       is Include -> {
-        val scanner = scanner(
-          interfaceName = subject.path.name,
-          packageName = subject.path.packageName ?: packageName,
-        )
         for (item in subject.items) {
-          scanner.yield(item.type)
+          yield(TypeReference(location, item.type))
         }
       }
 
-      is Interface -> scanner(interfaceName = subject.name).scan(subject.declarations)
-      is Package -> scan(subject.declarations)
-      is Record -> scan(subject.fields)
-      is Resource -> scan(subject.functions)
-      is TypeAlias -> yield(subject.target)
-      is Variant -> scan(subject.cases)
+      is TypeAlias -> yield(TypeReference(location, subject.target))
       is Use -> {
-        val scanner = scanner(
-          packageName = subject.path.packageName ?: packageName,
-          interfaceName = subject.path.name,
-        )
         for (item in subject.items) {
-          scanner.yield(item.type)
+          yield(TypeReference(location, item.type))
         }
-      }
-
-      is World -> {
-        val scanner = scanner(interfaceName = subject.name)
-        scanner.scan(subject.declarations)
-        scanner.scan(subject.imports)
-        scanner.scan(subject.exports)
       }
 
       else -> {}
-    }
-  }
-
-  /** Returns a new scanner instance, which provides context to yielded types. */
-  private fun scanner(
-    subject: Declaration = this.subject,
-    packageName: PackageName = this.packageName,
-    interfaceName: Identifier? = this.interfaceName,
-  ) = TypeReferenceScanner(
-    path = path,
-    subject = subject,
-    packageName = packageName,
-    interfaceName = interfaceName,
-  )
-
-  context(sequence: SequenceScope<TypeReference>)
-  private suspend fun scan(declarations: Iterable<Declaration>) {
-    for (declaration in declarations) {
-      scanner(subject = declaration).scan()
-    }
-  }
-
-  context(sequence: SequenceScope<TypeReference>)
-  private suspend fun yield(type: TypeName?) {
-    if (type != null) {
-      sequence.yield(TypeReference(path, subject.offset, packageName, interfaceName, type))
     }
   }
 }

--- a/support/wit/wit-core/src/jvmTest/kotlin/com/wasmo/support/wit/ReadAllWasiFilesTest.kt
+++ b/support/wit/wit-core/src/jvmTest/kotlin/com/wasmo/support/wit/ReadAllWasiFilesTest.kt
@@ -60,12 +60,12 @@ class ReadAllWasiFilesTest {
         try {
           index.getType(
             typeName = declaredType,
-            inPackageName = ref.packageName,
-            inInterfaceName = ref.interfaceName,
+            inPackageName = ref.location.packageName,
+            inInterfaceName = ref.location.interfaceName,
           )
         } catch (e: IllegalArgumentException) {
           throw IllegalArgumentException(
-            "failed to find ${ref.typeName} from ${ref.path} at ${ref.offset}", e,
+            "failed to find ${ref.typeName} from ${ref.location.path} at ${ref.location.offset}", e,
           )
         }
       }

--- a/support/wit/wit-core/src/jvmTest/kotlin/com/wasmo/support/wit/TypeReferenceTest.kt
+++ b/support/wit/wit-core/src/jvmTest/kotlin/com/wasmo/support/wit/TypeReferenceTest.kt
@@ -25,38 +25,48 @@ class TypeReferenceTest {
 
     assertThat(witPackage.typeReferences()).containsExactly(
       TypeReference(
-        path = path,
-        offset = Offset(3, 5),
-        packageName = "wasi:io@0.2.12".toPackageName(),
-        interfaceName = Identifier("poll"),
+        Location(
+          path = path,
+          offset = Offset(3, 5),
+          packageName = "wasi:io@0.2.12".toPackageName(),
+          interfaceName = Identifier("poll"),
+        ),
         typeName = TypeName.Declared("pollable"),
       ),
       TypeReference(
-        path = path,
-        offset = Offset(4, 5),
-        packageName = "wasi:clocks@0.2.12".toPackageName(),
-        interfaceName = Identifier("monotonic-clock"),
+        Location(
+          path = path,
+          offset = Offset(4, 5),
+          packageName = "wasi:clocks@0.2.12".toPackageName(),
+          interfaceName = Identifier("monotonic-clock"),
+        ),
         typeName = TypeName.U64,
       ),
       TypeReference(
-        path = path,
-        offset = Offset(5, 5),
-        packageName = "wasi:clocks@0.2.12".toPackageName(),
-        interfaceName = Identifier("monotonic-clock"),
+        Location(
+          path = path,
+          offset = Offset(5, 5),
+          packageName = "wasi:clocks@0.2.12".toPackageName(),
+          interfaceName = Identifier("monotonic-clock"),
+        ),
         typeName = TypeName.Declared("instant"),
       ),
       TypeReference(
-        path = path,
-        offset = Offset(6, 5),
-        packageName = "wasi:clocks@0.2.12".toPackageName(),
-        interfaceName = Identifier("monotonic-clock"),
+        Location(
+          path = path,
+          offset = Offset(6, 5),
+          packageName = "wasi:clocks@0.2.12".toPackageName(),
+          interfaceName = Identifier("monotonic-clock"),
+        ),
         typeName = TypeName.Declared("instant"),
       ),
       TypeReference(
-        path = path,
-        offset = Offset(6, 5),
-        packageName = "wasi:clocks@0.2.12".toPackageName(),
-        interfaceName = Identifier("monotonic-clock"),
+        Location(
+          path = path,
+          offset = Offset(6, 5),
+          packageName = "wasi:clocks@0.2.12".toPackageName(),
+          interfaceName = Identifier("monotonic-clock"),
+        ),
         typeName = TypeName.Declared("pollable"),
       ),
     )


### PR DESCRIPTION
The new structure is organized around a new type 'Location' that I intend to use everywhere I need to keep track of where I'm looking for a symbol.