### PR TITLE
Hook up OsConfig and drive kcoroutines debug with it

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version
 kotlinpoet = { module = "com.squareup:kotlinpoet", version = "2.3.0" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core-js = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-js", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/OsConfig.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/OsConfig.kt
@@ -3,13 +3,21 @@ package com.wasmo.api
 sealed interface OsConfig {
   val installAppsFromFileSystem: Boolean
 
+  val debugSqlQueries: Boolean
+
   object Standard : OsConfig {
     override val installAppsFromFileSystem: Boolean
+      get() = false
+
+    override val debugSqlQueries: Boolean
       get() = false
   }
 
   object DevMode : OsConfig {
     override val installAppsFromFileSystem: Boolean
+      get() = true
+
+    override val debugSqlQueries: Boolean
       get() = true
   }
 }

--- a/os/distributions/homelab/build.gradle.kts
+++ b/os/distributions/homelab/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
   implementation(libs.clikt)
   implementation(libs.clikt.core)
   implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.coroutines.debug)
   implementation(libs.ktor.server.core)
   implementation(libs.ktor.server.netty)
   implementation(libs.okhttp)

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabCommand.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabCommand.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
+import com.wasmo.api.OsConfig
 import com.wasmo.api.stripe.StripePublishableKey
 import com.wasmo.common.catalog.DevelopmentCatalog
 import com.wasmo.identifiers.Deployment
@@ -24,7 +25,9 @@ import com.wasmo.wiring.Distribution
 import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.createGraphFactory
 import io.ktor.server.engine.EmbeddedServer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.debug.DebugProbes
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okio.ByteString.Companion.encodeUtf8
@@ -34,6 +37,8 @@ import wasmo.sql.SqlDatabase
 class HomelabCommand : CliktCommand() {
   val container: Boolean by option("--container")
     .flag("--no-container", default = true)
+  val devMode: Boolean by option("--dev-mode")
+    .flag("--no-dev-mode", default = false)
   val stripePublishableKey: String by option()
     .defaultLazy {
       System.getenv("STRIPE_PUBLISHABLE_KEY")
@@ -45,6 +50,7 @@ class HomelabCommand : CliktCommand() {
         ?: "sk_UNKNOWN"
     }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   override fun run() = runBlocking {
     var baseUrl = "http://wasmo.localhost:8080/".toHttpUrl()
 
@@ -119,6 +125,24 @@ class HomelabCommand : CliktCommand() {
           objectStoreAddress = objectStoreAddress,
           sessionCookieSpec = SessionCookieSpec.Http,
           localPostgresql = localPostgresql,
+          osConfig = if (devMode) {
+            // Setup coroutines debugging.
+            DebugProbes.install()
+            DebugProbes.enableCreationStackTraces = true
+            DebugProbes.sanitizeStackTraces = true
+            System.setProperty(kotlinx.coroutines.DEBUG_PROPERTY_NAME, kotlinx.coroutines.DEBUG_PROPERTY_VALUE_ON)
+            System.setProperty("kotlinx.coroutines.stacktrace.recovery", "true")
+            OsConfig.DevMode
+          } else {
+            OsConfig.Standard
+          }.also {
+            println("OsConfig: $it")
+            println("DebugProbes.isInstalled: ${DebugProbes.isInstalled}")
+            println("DebugProbes.enableCreationStackTraces: ${DebugProbes.enableCreationStackTraces}")
+            println("${kotlinx.coroutines.DEBUG_PROPERTY_NAME}: ${System.getProperty(kotlinx.coroutines.DEBUG_PROPERTY_NAME)}")
+            val stackTraceRecovery = "kotlinx.coroutines.stacktrace.recovery"
+            println("$stackTraceRecovery: ${System.getProperty(stackTraceRecovery)}")
+          }
         )
         return serviceGraph.wasmoService
       }

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
@@ -4,6 +4,7 @@ import com.wasmo.accounts.AccountsBindings
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
 import com.wasmo.accounts.passkeys.AccountsPasskeysBindings
+import com.wasmo.api.OsConfig
 import com.wasmo.calls.CallGraph
 import com.wasmo.common.catalog.Catalog
 import com.wasmo.computers.ComputerServiceGraph
@@ -87,6 +88,7 @@ internal interface HomelabGraph {
       @Provides catalog: Catalog,
       @Provides postgresqlConfig: WasmoPostgresqlConfig,
       @Provides localPostgresql: LocalPostgresql,
+      @Provides osConfig: OsConfig,
     ): HomelabGraph
   }
 }


### PR DESCRIPTION
I had hoped the coroutines stuff would do more, but I think the stack trace rewriting may only come into play when the app dies.

As far as the injected value goes, I'd like to flag some other stuff with this, like verbose SQL logging, etc