### PR TITLE
Drop Homelab dependency on Stripe.

### DIFF
--- a/os/api/src/commonMain/kotlin/com/wasmo/api/OsHtml.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/OsHtml.kt
@@ -1,10 +1,10 @@
 package com.wasmo.api
 
+import com.wasmo.api.payments.ComputerPaymentMethod
 import com.wasmo.api.routes.RoutingContext
-import com.wasmo.api.stripe.StripePublishableKey
 
 interface OsHtml {
-  val stripePublishableKey: StripePublishableKey
+  val computerPaymentMethod: ComputerPaymentMethod
   val accountSnapshot: AccountSnapshot
   val routingContext: RoutingContext
   val inviteTicket: InviteTicket?

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/payments/ComputerPaymentMethod.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/payments/ComputerPaymentMethod.kt
@@ -1,0 +1,23 @@
+package com.wasmo.api.payments
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * How computers can be paid for.
+ */
+@Serializable
+sealed class ComputerPaymentMethod {
+  /** No payment possible - only works for computers that are free. */
+  @Serializable
+  @SerialName("payment-config-free")
+  data object FreeOnly : ComputerPaymentMethod()
+
+  /**
+   * Payment possible via Stripe - configured via StripePublishableKey, a dependency injection
+   * must be set up separately for distributions that need it.
+   */
+  @Serializable
+  @SerialName("payment-config-stripe")
+  data class Stripe(val stripePublishableKey: StripePublishableKey) : ComputerPaymentMethod()
+}

--- a/os/api/src/commonMain/kotlin/com/wasmo/api/payments/StripePublishableKey.kt
+++ b/os/api/src/commonMain/kotlin/com/wasmo/api/payments/StripePublishableKey.kt
@@ -1,4 +1,4 @@
-package com.wasmo.api.stripe
+package com.wasmo.api.payments
 
 import kotlinx.serialization.Serializable
 

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/WasmoWebAppGraph.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/WasmoWebAppGraph.kt
@@ -3,11 +3,11 @@ package com.wasmo.client.app
 import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.ComputerSnapshot
+import com.wasmo.api.payments.ComputerPaymentMethod
 import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.WasmoApi
 import com.wasmo.api.routes.RouteCodec
 import com.wasmo.api.routes.RoutingContext
-import com.wasmo.api.stripe.StripePublishableKey
 import com.wasmo.client.app.api.RealWasmoApi
 import com.wasmo.client.app.browser.Browser
 import com.wasmo.client.app.browser.RealBrowser
@@ -51,9 +51,9 @@ interface WasmoWebAppGraph {
 
   @Provides
   @SingleIn(ClientAppScope::class)
-  fun provideStripePublishableKey(pageData: PageData): StripePublishableKey =
-    pageData.get<StripePublishableKey>("stripe_publishable_key")
-      ?: error("required stripe_publishable_key pageData not found")
+  fun providePaymentConfig(pageData: PageData): ComputerPaymentMethod =
+    pageData.get<ComputerPaymentMethod>("computer_payment_method")
+      ?: error("required computer_payment_method pageData not found")
 
   @Provides
   @SingleIn(ClientAppScope::class)

--- a/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/stripe/CheckoutSession.kt
+++ b/os/client/app/src/jsMain/kotlin/com/wasmo/client/app/stripe/CheckoutSession.kt
@@ -1,6 +1,6 @@
 package com.wasmo.client.app.stripe
 
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.ComputerPaymentMethod
 import com.wasmo.client.identifiers.ClientAppScope
 import com.wasmo.compose.Checkout
 import com.wasmo.compose.InitEmbeddedCheckoutOptions
@@ -8,6 +8,7 @@ import com.wasmo.compose.Stripe
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlin.js.Promise
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.asDeferred
@@ -40,19 +41,27 @@ class CheckoutSession private constructor(
   @Inject
   @SingleIn(ClientAppScope::class)
   class Factory(
-    private val stripePublishableKey: StripePublishableKey,
+    private val computerPaymentMethod: ComputerPaymentMethod,
   ) {
     fun create(
       coroutineScope: CoroutineScope,
       clientSecret: String,
     ): CheckoutSession {
-      val stripe = Stripe(stripePublishableKey.publishableKey)
-      val deferredCheckout = stripe.initEmbeddedCheckout(
-        InitEmbeddedCheckoutOptions(
-          fetchClientSecret = { Promise.resolve(clientSecret) },
-        ),
-      ).asDeferred()
-
+      val deferredCheckout = when (computerPaymentMethod) {
+        is ComputerPaymentMethod.FreeOnly -> {
+          CompletableDeferred<Checkout>().apply {
+            completeExceptionally(UnsupportedOperationException("checkout not supported"))
+          }
+        }
+        is ComputerPaymentMethod.Stripe -> {
+          val stripe = Stripe(computerPaymentMethod.stripePublishableKey.publishableKey)
+          stripe.initEmbeddedCheckout(
+            InitEmbeddedCheckoutOptions(
+              fetchClientSecret = { Promise.resolve(clientSecret) },
+            ),
+          ).asDeferred()
+        }
+      }
       return CheckoutSession(
         deferredCheckout = deferredCheckout,
         coroutineScope = coroutineScope,

--- a/os/distributions/homelab/build.gradle.kts
+++ b/os/distributions/homelab/build.gradle.kts
@@ -52,8 +52,6 @@ jib {
 
     // TODO(jwilson): these secrets aren't used. Stop requiring them.
     environment = mapOf(
-      "STRIPE_PUBLISHABLE_KEY" to ("pk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
-      "STRIPE_SECRET_KEY" to ("sk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
       "POSTMARK_SERVER_TOKEN" to ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
     )
   }
@@ -99,7 +97,6 @@ dependencies {
   implementation(projects.os.server.objectstore.s3)
   implementation(projects.os.server.okhttpclient)
   implementation(projects.os.server.passkeys.real)
-  implementation(projects.os.server.payments.stripe)
   implementation(projects.os.server.permits.real)
   implementation(projects.os.server.postgresqloperator.api)
   implementation(projects.os.server.postgresqloperator.exec)

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabCommand.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabCommand.kt
@@ -6,7 +6,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
-import com.wasmo.api.stripe.StripePublishableKey
 import com.wasmo.common.catalog.DevelopmentCatalog
 import com.wasmo.events.LoggingEventListener
 import com.wasmo.identifiers.Deployment
@@ -21,7 +20,6 @@ import com.wasmo.sendemail.postmark.PostmarkCredentials
 import com.wasmo.sendemail.postmark.PostmarkProductionBaseUrl
 import com.wasmo.sql.ProvisioningDb
 import com.wasmo.sql.WasmoPostgresqlConfig
-import com.wasmo.stripe.StripeCredentials
 import com.wasmo.wiring.Distribution
 import com.wasmo.wiring.WasmoService
 import dev.zacsweers.metro.createGraphFactory
@@ -40,16 +38,6 @@ class HomelabCommand : CliktCommand() {
     .flag("--no-container", default = true)
   val devMode: Boolean by option("--dev-mode")
     .flag("--no-dev-mode", default = false)
-  val stripePublishableKey: String by option()
-    .defaultLazy {
-      System.getenv("STRIPE_PUBLISHABLE_KEY")
-        ?: "pk_UNKNOWN"
-    }
-  val stripeSecretKey: String by option()
-    .defaultLazy {
-      System.getenv("STRIPE_SECRET_KEY")
-        ?: "sk_UNKNOWN"
-    }
 
   @OptIn(ExperimentalCoroutinesApi::class)
   override fun run() = runBlocking {
@@ -133,10 +121,6 @@ class HomelabCommand : CliktCommand() {
           postmarkCredentials = PostmarkCredentials(
             baseUrl = PostmarkProductionBaseUrl,
             serverToken = System.getenv("POSTMARK_SERVER_TOKEN") ?: "?",
-          ),
-          stripeCredentials = StripeCredentials(
-            publishableKey = StripePublishableKey(stripePublishableKey),
-            secretKey = stripeSecretKey,
           ),
           catalog = DevelopmentCatalog,
           wasmoDb = wasmoDb,

--- a/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
+++ b/os/distributions/homelab/src/main/kotlin/com/wasmo/distributions/homelab/HomelabGraph.kt
@@ -30,8 +30,6 @@ import com.wasmo.sendemail.postmark.PostmarkCredentials
 import com.wasmo.sql.ProvisioningDb
 import com.wasmo.sql.SqlServiceBindings
 import com.wasmo.sql.WasmoPostgresqlConfig
-import com.wasmo.stripe.StripeBindings
-import com.wasmo.stripe.StripeCredentials
 import com.wasmo.usernames.UsernameBindings
 import com.wasmo.website.WebsiteBindings
 import com.wasmo.wiring.ObjectStoreBindings
@@ -63,7 +61,6 @@ import wasmo.sql.SqlDatabase
     S3ObjectStoreBindings::class,
     ServiceBindings::class,
     SqlServiceBindings::class,
-    StripeBindings::class,
     UsernameBindings::class,
     WebsiteBindings::class,
   ],
@@ -84,7 +81,6 @@ internal interface HomelabGraph {
       @Provides cookieSecret: CookieSecret,
       @Provides deployment: Deployment,
       @Provides sessionCookieSpec: SessionCookieSpec,
-      @Provides stripeCredentials: StripeCredentials,
       @Provides objectStoreAddress: ObjectStoreAddress,
       @Provides catalog: Catalog,
       @Provides postgresqlConfig: WasmoPostgresqlConfig,

--- a/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedCommand.kt
+++ b/os/distributions/hosted/src/main/kotlin/com/wasmo/distributions/hosted/HostedCommand.kt
@@ -3,7 +3,7 @@ package com.wasmo.distributions.hosted
 import com.github.ajalt.clikt.core.CliktCommand
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.StripePublishableKey
 import com.wasmo.common.catalog.DevelopmentCatalog
 import com.wasmo.identifiers.Deployment
 import com.wasmo.identifiers.DistributionShortCode

--- a/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxCommand.kt
+++ b/os/distributions/sandbox/src/main/kotlin/com/wasmo/distributions/sandbox/SandboxCommand.kt
@@ -3,7 +3,7 @@ package com.wasmo.distributions.sandbox
 import com.github.ajalt.clikt.core.CliktCommand
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.StripePublishableKey
 import com.wasmo.common.catalog.DevelopmentCatalog
 import com.wasmo.identifiers.Deployment
 import com.wasmo.identifiers.DistributionShortCode

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeComputersBindings.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/FreeComputersBindings.kt
@@ -1,8 +1,10 @@
 package com.wasmo.computers.free
 
+import com.wasmo.api.payments.ComputerPaymentMethod
 import com.wasmo.framework.ActionRegistration
 import com.wasmo.identifiers.HostnamePatterns
 import com.wasmo.identifiers.OsScope
+import com.wasmo.payments.PaymentsService
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
@@ -22,5 +24,16 @@ abstract class FreeComputersBindings {
         path = "/create-computer-spec",
         action = FreeCreateComputerSpecRpc::class,
       )
+
+    // TODO: Consider moving no-payment ComputerPaymentMethod and PaymentsService bindings to a
+    // sibling of StripeBindings, since the paid versions are defined by StripeBindings.
+    // Alternative, create a StripeComputersBindings module that depends on both.
+    @Provides
+    @SingleIn(OsScope::class)
+    fun provideComputerPaymentConfig(): ComputerPaymentMethod = ComputerPaymentMethod.FreeOnly
+
+    @Provides
+    @SingleIn(OsScope::class)
+    fun providePaymentsService(): PaymentsService = NoPaymentsService()
   }
 }

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/NoPaymentsService.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/free/NoPaymentsService.kt
@@ -1,0 +1,22 @@
+package com.wasmo.computers.free
+
+import com.wasmo.payments.CheckoutSession
+import com.wasmo.payments.CreateCheckoutSessionRequest
+import com.wasmo.payments.CreateCheckoutSessionResponse
+import com.wasmo.payments.PaymentsService
+import com.wasmo.payments.Subscription
+
+class NoPaymentsService : PaymentsService {
+  override fun createCheckoutSession(request: CreateCheckoutSessionRequest): CreateCheckoutSessionResponse {
+    throw UnsupportedOperationException("No payments service available")
+  }
+
+  override fun getCheckoutSession(checkoutSessionId: String): CheckoutSession {
+    throw UnsupportedOperationException("No payments service available")
+  }
+
+  override fun getSubscription(subscriptionId: String): Subscription {
+    // TBD: Should we create a DbSubscriptionPeriod even for computers that are free?
+    throw UnsupportedOperationException("No payments service available")
+  }
+}

--- a/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidComputersBindings.kt
+++ b/os/server/computers/real/src/jvmMain/kotlin/com/wasmo/computers/paid/PaidComputersBindings.kt
@@ -1,8 +1,11 @@
 package com.wasmo.computers.paid
 
+import com.wasmo.api.payments.ComputerPaymentMethod
+import com.wasmo.api.payments.StripePublishableKey
 import com.wasmo.framework.ActionRegistration
 import com.wasmo.identifiers.HostnamePatterns
 import com.wasmo.identifiers.OsScope
+import com.wasmo.payments.PaymentsService
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
@@ -22,5 +25,9 @@ abstract class PaidComputersBindings {
         path = "/create-computer-spec",
         action = PaidCreateComputerSpecRpc::class,
       )
+    @Provides
+    @SingleIn(OsScope::class)
+    fun provideComputerPaymentConfig(stripePublishableKey: StripePublishableKey): ComputerPaymentMethod =
+      ComputerPaymentMethod.Stripe(stripePublishableKey)
   }
 }

--- a/os/server/payments/stripe/src/jvmMain/kotlin/com/wasmo/stripe/StripeBindings.kt
+++ b/os/server/payments/stripe/src/jvmMain/kotlin/com/wasmo/stripe/StripeBindings.kt
@@ -1,7 +1,7 @@
 package com.wasmo.stripe
 
 import com.stripe.StripeClient
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.StripePublishableKey
 import com.wasmo.common.catalog.Catalog
 import com.wasmo.framework.ActionRegistration
 import com.wasmo.identifiers.Deployment

--- a/os/server/payments/stripe/src/jvmMain/kotlin/com/wasmo/stripe/StripeCredentials.kt
+++ b/os/server/payments/stripe/src/jvmMain/kotlin/com/wasmo/stripe/StripeCredentials.kt
@@ -1,6 +1,6 @@
 package com.wasmo.stripe
 
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.StripePublishableKey
 
 data class StripeCredentials(
   val publishableKey: StripePublishableKey,

--- a/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTesterBindings.kt
+++ b/os/server/testing/src/jvmMain/kotlin/com/wasmo/testing/service/ServiceTesterBindings.kt
@@ -2,7 +2,8 @@ package com.wasmo.testing.service
 
 import com.wasmo.accounts.CookieSecret
 import com.wasmo.accounts.SessionCookieSpec
-import com.wasmo.api.stripe.StripePublishableKey
+import com.wasmo.api.payments.ComputerPaymentMethod
+import com.wasmo.api.payments.StripePublishableKey
 import com.wasmo.computers.AppCatalog
 import com.wasmo.events.EventListener
 import com.wasmo.framework.ContentTypeDatabase
@@ -84,8 +85,8 @@ abstract class ServiceTesterBindings {
 
     @Provides
     @SingleIn(OsScope::class)
-    fun provideStripePublishableKey(): StripePublishableKey =
-      StripePublishableKey("pk_test_5544332211")
+    fun provideComputerPaymentMethod(): ComputerPaymentMethod =
+      ComputerPaymentMethod.Stripe(StripePublishableKey("pk_test_5544332211"))
 
     @Provides
     @SingleIn(OsScope::class)

--- a/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/RealServerOsHtml.kt
+++ b/os/server/website/real/src/jvmMain/kotlin/com/wasmo/website/RealServerOsHtml.kt
@@ -4,10 +4,10 @@ import com.wasmo.api.AccountSnapshot
 import com.wasmo.api.ComputerListSnapshot
 import com.wasmo.api.ComputerSnapshot
 import com.wasmo.api.InviteTicket
+import com.wasmo.api.payments.ComputerPaymentMethod
 import com.wasmo.api.SignInSnapshot
 import com.wasmo.api.WasmoJson
 import com.wasmo.api.routes.RoutingContext
-import com.wasmo.api.stripe.StripePublishableKey
 import com.wasmo.framework.ContentTypes
 import com.wasmo.framework.MapPageData
 import com.wasmo.framework.Response
@@ -30,7 +30,7 @@ import okio.BufferedSink
 @AssistedInject
 class RealServerOsHtml(
   override val deployment: Deployment,
-  override val stripePublishableKey: StripePublishableKey,
+  override val computerPaymentMethod: ComputerPaymentMethod,
   @Assisted override val accountSnapshot: AccountSnapshot,
   @Assisted override val routingContext: RoutingContext,
   @Assisted override val inviteTicket: InviteTicket?,
@@ -40,7 +40,7 @@ class RealServerOsHtml(
 ) : ServerOsHtml, ResponseBody {
   val pageData: MapPageData
     get() = MapPageData.Builder(WasmoJson)
-      .put("stripe_publishable_key", stripePublishableKey)
+      .put("computer_payment_method", computerPaymentMethod)
       .put("routing_context", routingContext)
       .put("account_snapshot", accountSnapshot)
       .apply {

--- a/os/server/wiring/build.gradle.kts
+++ b/os/server/wiring/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
         implementation(projects.os.server.objectstore.s3)
         implementation(projects.os.server.okhttpclient)
         implementation(projects.os.server.passkeys.real)
-        implementation(projects.os.server.payments.stripe)
         implementation(projects.os.server.permits.real)
         implementation(projects.os.server.postgresqloperator.api)
         implementation(projects.os.server.sendemail.postmark)


### PR DESCRIPTION
Drop Homelab dependency on Stripe via STRIPE_PUBLISHABLE_KEY and STRIPE_SECRET_KEY environment variables.

The paid vs. free distinction is now done through polymorphism in more places:

   - ComputerPaymentMethod.{Free,Stripe} replaces StripePublishableKey
     at places that at compile time might encounter either, e.g.
     RealServerOsHtml or CheckoutSession.Factory.
     - The latter produces an
       immediately-failed checkout session if invoked.
     - ComputerPaymentMethod lives in `com.wasmi.api.payments`, which
       was renamed from `*.stripe` and is consistent with
       `com.wasmo.payments`.
   - PaymentsService gains a new implementation NoPaymentsService that
     fails at runtime if used.

Notes:

 - Distributions will now depend on StripeBindings iff they use
   PaidComputersBindings (as opposed to FreeComputersBindings). We may
   want to combine the two, or more likely move the bindings of
   ComputerPaymentsMethod and PaymentsService from FreeComputersBindings
   to some free sibling of StripeBindings.
 - I experimented with separating the paid vs. free computers code more
   strictly into different compilation units, but that ballooned into
   too much boilerplate; it reduces flexibility for us to configure
   both paid and free options in the same distribution later, too.
   Not worth it.

**Tested**: Homelab only, i.e.:

`./gradlew os:distributions:homelab:run --args="--no-container"`