### PR TITLE
Bump Absurd to 0.4.0

### DIFF
--- a/os/server/db/src/jvmMain/resources/migrations/v5__absurd_upgrade_0.4.0.sql
+++ b/os/server/db/src/jvmMain/resources/migrations/v5__absurd_upgrade_0.4.0.sql
@@ -1,0 +1,2001 @@
+-- Migration from 0.3.0 to main
+--
+-- Minimal schema delta from 0.3.0 to current main.
+
+alter table absurd.queues
+  add column if not exists storage_mode text,
+  add column if not exists default_partition text,
+  add column if not exists partition_lookahead interval,
+  add column if not exists partition_lookback interval,
+  add column if not exists cleanup_ttl interval,
+  add column if not exists cleanup_limit integer,
+  add column if not exists detach_mode text,
+  add column if not exists detach_min_age interval;
+
+update absurd.queues
+set storage_mode = coalesce(storage_mode, 'unpartitioned'),
+    default_partition = coalesce(default_partition, 'enabled'),
+    partition_lookahead = coalesce(partition_lookahead, interval '28 days'),
+    partition_lookback = coalesce(partition_lookback, interval '1 day'),
+    cleanup_ttl = coalesce(cleanup_ttl, interval '30 days'),
+    cleanup_limit = coalesce(cleanup_limit, 1000),
+    detach_mode = coalesce(detach_mode, 'none'),
+    detach_min_age = coalesce(detach_min_age, interval '30 days')
+where storage_mode is null
+   or default_partition is null
+   or partition_lookahead is null
+   or partition_lookback is null
+   or cleanup_ttl is null
+   or cleanup_limit is null
+   or detach_mode is null
+   or detach_min_age is null;
+
+alter table absurd.queues
+  alter column storage_mode set default 'unpartitioned',
+alter column storage_mode set not null,
+  alter column default_partition set default 'enabled',
+  alter column default_partition set not null,
+  alter column partition_lookahead set default interval '28 days',
+  alter column partition_lookahead set not null,
+  alter column partition_lookback set default interval '1 day',
+  alter column partition_lookback set not null,
+  alter column cleanup_ttl set default interval '30 days',
+  alter column cleanup_ttl set not null,
+  alter column cleanup_limit set default 1000,
+  alter column cleanup_limit set not null,
+  alter column detach_mode set default 'none',
+  alter column detach_mode set not null,
+  alter column detach_min_age set default interval '30 days',
+  alter column detach_min_age set not null;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_storage_mode_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_storage_mode_check
+    check (storage_mode in ('unpartitioned', 'partitioned'));
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_default_partition_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_default_partition_check
+    check (default_partition in ('enabled', 'disabled'));
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_partition_lookahead_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_partition_lookahead_check
+    check (partition_lookahead >= interval '0 seconds');
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_partition_lookback_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_partition_lookback_check
+    check (partition_lookback >= interval '0 seconds');
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_cleanup_ttl_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_cleanup_ttl_check
+    check (cleanup_ttl >= interval '0 seconds');
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_cleanup_limit_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_cleanup_limit_check
+    check (cleanup_limit >= 1);
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_detach_mode_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_detach_mode_check
+    check (detach_mode in ('none', 'empty'));
+end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'absurd.queues'::regclass
+      and conname = 'queues_detach_min_age_check'
+  ) then
+alter table absurd.queues
+  add constraint queues_detach_min_age_check
+    check (detach_min_age >= interval '0 seconds');
+end if;
+end;
+$$;
+
+create or replace function absurd.get_schema_version ()
+  returns text
+  language sql
+as $$
+select '0.4.0'::text;
+$$;
+
+create or replace function absurd.validate_queue_name (p_queue_name text)
+  returns text
+  language plpgsql
+as $$
+begin
+  if p_queue_name is null or p_queue_name = '' then
+    raise exception 'Queue name must be provided';
+end if;
+
+  if octet_length(p_queue_name) > 57 then
+    raise exception 'Queue name "%" is too long (max 57 bytes).', p_queue_name;
+end if;
+
+return p_queue_name;
+end;
+$$;
+
+create or replace function absurd.ensure_queue_tables (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+declare
+v_storage_mode text := 'unpartitioned';
+  v_t_suffix text;
+  v_r_suffix text;
+  v_c_suffix text;
+  v_w_suffix text;
+  v_t_idempotency_def text;
+begin
+  perform absurd.validate_queue_name(p_queue_name);
+
+select storage_mode into v_storage_mode
+from absurd.queues
+where queue_name = p_queue_name;
+
+v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+end if;
+
+  if v_storage_mode = 'partitioned' then
+    v_t_suffix := 'partition by range (task_id)';
+    v_r_suffix := 'partition by range (run_id)';
+    v_c_suffix := 'partition by range (task_id)';
+    v_w_suffix := 'partition by range (run_id)';
+    v_t_idempotency_def := 'idempotency_key text';
+else
+    v_t_suffix := 'with (fillfactor=70)';
+    v_r_suffix := 'with (fillfactor=70)';
+    v_c_suffix := 'with (fillfactor=70)';
+    v_w_suffix := '';
+    v_t_idempotency_def := 'idempotency_key text unique';
+end if;
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid primary key,
+      task_name text not null,
+      params jsonb not null,
+      headers jsonb,
+      retry_strategy jsonb,
+      max_attempts integer,
+      cancellation jsonb,
+      enqueue_at timestamptz not null default absurd.current_time(),
+      first_started_at timestamptz,
+      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+      attempts integer not null default 0,
+      last_attempt_run uuid,
+      completed_payload jsonb,
+      cancelled_at timestamptz,
+      %s
+   ) %s',
+  't_' || p_queue_name,
+  v_t_idempotency_def,
+  v_t_suffix
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      run_id uuid primary key,
+      task_id uuid not null,
+      attempt integer not null,
+      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+      claimed_by text,
+      claim_expires_at timestamptz,
+      available_at timestamptz not null,
+      wake_event text,
+      event_payload jsonb,
+      started_at timestamptz,
+      completed_at timestamptz,
+      failed_at timestamptz,
+      result jsonb,
+      failure_reason jsonb,
+      created_at timestamptz not null default absurd.current_time()
+   ) %s',
+  'r_' || p_queue_name,
+  v_r_suffix
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid not null,
+      checkpoint_name text not null,
+      state jsonb,
+      status text not null default ''committed'',
+      owner_run_id uuid,
+      updated_at timestamptz not null default absurd.current_time(),
+      primary key (task_id, checkpoint_name)
+   ) %s',
+  'c_' || p_queue_name,
+  v_c_suffix
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      event_name text primary key,
+      payload jsonb,
+      emitted_at timestamptz not null default absurd.current_time()
+   )',
+  'e_' || p_queue_name
+        );
+
+execute format(
+  'create table if not exists absurd.%I (
+      task_id uuid not null,
+      run_id uuid not null,
+      step_name text not null,
+      event_name text not null,
+      timeout_at timestamptz,
+      created_at timestamptz not null default absurd.current_time(),
+      primary key (run_id, step_name)
+   ) %s',
+  'w_' || p_queue_name,
+  v_w_suffix
+        );
+
+if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          idempotency_key text primary key,
+          task_id uuid not null
+       )',
+      'i_' || p_queue_name
+    );
+end if;
+
+execute format(
+  'create index if not exists %I on absurd.%I (state, available_at)',
+  ('r_' || p_queue_name) || '_sai',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (task_id)',
+  ('r_' || p_queue_name) || '_ti',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (claim_expires_at)
+    where state = ''running''
+      and claim_expires_at is not null',
+  ('r_' || p_queue_name) || '_cei',
+  'r_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (event_name)',
+  ('w_' || p_queue_name) || '_eni',
+  'w_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (task_id)',
+  ('w_' || p_queue_name) || '_ti',
+  'w_' || p_queue_name
+        );
+
+execute format(
+  'create index if not exists %I on absurd.%I (emitted_at)',
+  ('e_' || p_queue_name) || '_eai',
+  'e_' || p_queue_name
+        );
+
+if v_storage_mode = 'partitioned' then
+    execute format(
+      'create index if not exists %I on absurd.%I (task_id)',
+      ('i_' || p_queue_name) || '_ti',
+      'i_' || p_queue_name
+    );
+
+    perform absurd.ensure_partitions(p_queue_name);
+end if;
+end;
+$$;
+
+create or replace function absurd.create_queue (
+  p_queue_name text,
+  p_storage_mode text
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_storage_mode text;
+  v_existing_mode text;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  v_storage_mode := lower(trim(coalesce(p_storage_mode, '')));
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', p_storage_mode;
+end if;
+
+insert into absurd.queues (queue_name, storage_mode)
+values (p_queue_name, v_storage_mode)
+  on conflict (queue_name) do nothing;
+
+select storage_mode into v_existing_mode
+from absurd.queues
+where queue_name = p_queue_name;
+
+if v_existing_mode is null then
+    raise exception 'Queue "%" was not found after create attempt', p_queue_name;
+end if;
+
+  if v_existing_mode <> v_storage_mode then
+    raise exception 'Queue "%" already exists with storage mode "%"', p_queue_name, v_existing_mode;
+end if;
+
+  perform absurd.ensure_queue_tables(p_queue_name);
+end;
+$$;
+
+create or replace function absurd.create_queue (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+begin
+  perform absurd.create_queue(p_queue_name, 'unpartitioned');
+end;
+$$;
+
+create or replace function absurd.drop_queue (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+declare
+v_existing_queue text;
+begin
+select queue_name into v_existing_queue
+from absurd.queues
+where queue_name = p_queue_name;
+
+if v_existing_queue is null then
+    return;
+end if;
+
+  -- Remove queue-scoped maintenance jobs only when pg_cron is available.
+  if to_regclass('cron.job') is not null and exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    perform absurd.disable_cron(p_queue_name);
+end if;
+
+execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'e_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'c_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 'r_' || p_queue_name);
+execute format('drop table if exists absurd.%I cascade', 't_' || p_queue_name);
+
+delete from absurd.queues where queue_name = p_queue_name;
+end;
+$$;
+
+create or replace function absurd.get_queue_policy (
+  p_queue_name text
+)
+  returns table (
+    queue_name text,
+    storage_mode text,
+    default_partition text,
+    partition_lookahead interval,
+    partition_lookback interval,
+    cleanup_ttl interval,
+    cleanup_limit integer,
+    detach_mode text,
+    detach_min_age interval
+  )
+  language sql
+as $$
+select
+  q.queue_name,
+  q.storage_mode,
+  q.default_partition,
+  q.partition_lookahead,
+  q.partition_lookback,
+  q.cleanup_ttl,
+  q.cleanup_limit,
+  q.detach_mode,
+  q.detach_min_age
+from absurd.queues q
+where q.queue_name = p_queue_name;
+$$;
+
+create or replace function absurd.set_queue_policy (
+  p_queue_name text,
+  p_policy jsonb
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_policy jsonb := coalesce(p_policy, '{}'::jsonb);
+  v_unknown_key text;
+  v_exists boolean := false;
+  v_storage_mode text;
+  v_default_partition text;
+  v_previous_default_partition text;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_default_table text;
+  v_default_attached boolean;
+  v_default_has_rows boolean;
+
+  v_partition_lookahead interval;
+  v_partition_lookback interval;
+  v_cleanup_ttl interval;
+  v_cleanup_limit integer;
+  v_detach_mode text;
+  v_detach_min_age interval;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  if jsonb_typeof(v_policy) <> 'object' then
+    raise exception 'Queue policy must be a JSON object';
+end if;
+
+select k.key
+into v_unknown_key
+from jsonb_object_keys(v_policy) as k(key)
+where k.key not in (
+                    'partition_lookahead',
+                    'partition_lookback',
+                    'cleanup_ttl',
+                    'cleanup_limit',
+                    'detach_mode',
+                    'detach_min_age',
+                    'default_partition'
+  )
+  limit 1;
+
+if v_unknown_key is not null then
+    raise exception 'Unsupported queue policy key "%"', v_unknown_key;
+end if;
+
+select exists (
+  select 1
+  from absurd.queues
+  where queue_name = p_queue_name
+)
+into v_exists;
+
+if not v_exists then
+    raise exception 'Queue "%" does not exist', p_queue_name;
+end if;
+
+select
+  storage_mode,
+  default_partition,
+  partition_lookahead,
+  partition_lookback,
+  cleanup_ttl,
+  cleanup_limit,
+  detach_mode,
+  detach_min_age
+into
+  v_storage_mode,
+  v_default_partition,
+  v_partition_lookahead,
+  v_partition_lookback,
+  v_cleanup_ttl,
+  v_cleanup_limit,
+  v_detach_mode,
+  v_detach_min_age
+from absurd.queues
+where queue_name = p_queue_name
+  for update;
+
+if v_policy ? 'partition_lookahead' then
+    v_partition_lookahead := (v_policy->>'partition_lookahead')::interval;
+end if;
+
+  if v_policy ? 'partition_lookback' then
+    v_partition_lookback := (v_policy->>'partition_lookback')::interval;
+end if;
+
+  if v_policy ? 'cleanup_ttl' then
+    v_cleanup_ttl := (v_policy->>'cleanup_ttl')::interval;
+end if;
+
+  if v_policy ? 'cleanup_limit' then
+    v_cleanup_limit := (v_policy->>'cleanup_limit')::integer;
+end if;
+
+  if v_policy ? 'detach_mode' then
+    v_detach_mode := lower(trim(coalesce(v_policy->>'detach_mode', '')));
+end if;
+
+  if v_policy ? 'detach_min_age' then
+    v_detach_min_age := (v_policy->>'detach_min_age')::interval;
+end if;
+
+  v_previous_default_partition := v_default_partition;
+
+  if v_policy ? 'default_partition' then
+    v_default_partition := lower(trim(coalesce(v_policy->>'default_partition', '')));
+end if;
+
+  if v_partition_lookahead < interval '0 seconds' then
+    raise exception 'partition_lookahead must be non-negative';
+end if;
+
+  if v_partition_lookback < interval '0 seconds' then
+    raise exception 'partition_lookback must be non-negative';
+end if;
+
+  if v_cleanup_ttl < interval '0 seconds' then
+    raise exception 'cleanup_ttl must be non-negative';
+end if;
+
+  if v_cleanup_limit < 1 then
+    raise exception 'cleanup_limit must be at least 1';
+end if;
+
+  if v_detach_mode not in ('none', 'empty') then
+    raise exception 'Unsupported detach mode "%"', v_detach_mode;
+end if;
+
+  if v_detach_min_age < interval '0 seconds' then
+    raise exception 'detach_min_age must be non-negative';
+end if;
+
+  if v_default_partition not in ('enabled', 'disabled') then
+    raise exception 'Unsupported default_partition mode "%"', v_default_partition;
+end if;
+
+  if v_storage_mode <> 'partitioned' and v_policy ? 'default_partition' then
+    raise exception 'default_partition policy is only supported for partitioned queues';
+end if;
+
+update absurd.queues
+set default_partition = v_default_partition,
+    partition_lookahead = v_partition_lookahead,
+    partition_lookback = v_partition_lookback,
+    cleanup_ttl = v_cleanup_ttl,
+    cleanup_limit = v_cleanup_limit,
+    detach_mode = v_detach_mode,
+    detach_min_age = v_detach_min_age
+where queue_name = p_queue_name;
+
+if v_storage_mode = 'partitioned'
+     and v_previous_default_partition <> v_default_partition then
+    if v_default_partition = 'enabled' then
+      perform absurd.ensure_partitions(p_queue_name);
+else
+      foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+        v_parent_table := v_parent_prefix || '_' || p_queue_name;
+        v_default_table := v_parent_table || '_d';
+
+select exists (
+  select 1
+  from pg_inherits inh
+         join pg_class parent on parent.oid = inh.inhparent
+         join pg_class child on child.oid = inh.inhrelid
+         join pg_namespace n on n.oid = parent.relnamespace
+  where n.nspname = 'absurd'
+    and parent.relname = v_parent_table
+    and child.relname = v_default_table
+)
+into v_default_attached;
+
+if not coalesce(v_default_attached, false) then
+          continue;
+end if;
+
+        -- Block out-of-window writes into the default partition while we
+        -- validate emptiness and detach/drop it.
+execute format(
+  'lock table absurd.%I in access exclusive mode',
+  v_default_table
+        );
+
+execute format(
+  'select exists (select 1 from absurd.%I limit 1)',
+  v_default_table
+        )
+  into v_default_has_rows;
+
+if coalesce(v_default_has_rows, false) then
+          raise exception
+            'Cannot disable default_partition for queue "%": default partition "%" is not empty',
+            p_queue_name,
+            v_default_table;
+end if;
+
+execute format(
+  'alter table absurd.%I detach partition absurd.%I',
+  v_parent_table,
+  v_default_table
+        );
+execute format('drop table if exists absurd.%I', v_default_table);
+end loop;
+end if;
+end if;
+end;
+$$;
+
+create or replace function absurd.spawn_task (
+  p_queue_name text,
+  p_task_name text,
+  p_params jsonb,
+  p_options jsonb default '{}'::jsonb
+)
+  returns table (
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
+  language plpgsql
+as $$
+declare
+v_task_id uuid := absurd.portable_uuidv7();
+  v_run_id uuid := absurd.portable_uuidv7();
+  v_attempt integer := 1;
+  v_headers jsonb;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_cancellation jsonb;
+  v_idempotency_key text;
+  v_existing_task_id uuid;
+  v_existing_run_id uuid;
+  v_existing_attempt integer;
+  v_row_count integer;
+  v_storage_mode text := 'unpartitioned';
+  v_task_inserted boolean := false;
+  v_now timestamptz := absurd.current_time();
+  v_params jsonb := coalesce(p_params, 'null'::jsonb);
+begin
+  if p_task_name is null or length(trim(p_task_name)) = 0 then
+    raise exception 'task_name must be provided';
+end if;
+
+  if p_options is not null then
+    v_headers := p_options->'headers';
+    v_retry_strategy := p_options->'retry_strategy';
+    if p_options ? 'max_attempts' then
+      v_max_attempts := (p_options->>'max_attempts')::int;
+      if v_max_attempts is not null and v_max_attempts < 1 then
+        raise exception 'max_attempts must be >= 1';
+end if;
+end if;
+    v_cancellation := p_options->'cancellation';
+    v_idempotency_key := p_options->>'idempotency_key';
+end if;
+
+  if v_idempotency_key is not null then
+select storage_mode into v_storage_mode
+from absurd.queues
+where queue_name = p_queue_name;
+
+v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+    if v_storage_mode not in ('unpartitioned', 'partitioned') then
+      raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+end if;
+
+    if v_storage_mode = 'partitioned' then
+      -- Reserve idempotency key via dedicated side table.
+      execute format(
+        'insert into absurd.%I (idempotency_key, task_id)
+         values ($1, $2)
+         on conflict (idempotency_key) do nothing',
+        'i_' || p_queue_name
+      )
+      using v_idempotency_key, v_task_id;
+
+get diagnostics v_row_count = row_count;
+
+if v_row_count = 0 then
+        execute format(
+          'select i.task_id, t.last_attempt_run, t.attempts
+             from absurd.%I i
+             join absurd.%I t on t.task_id = i.task_id
+            where i.idempotency_key = $1
+              for key share of i',
+          'i_' || p_queue_name,
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        if v_existing_task_id is null then
+          raise exception 'Idempotency key "%" in queue "%" was concurrently cleaned up', v_idempotency_key, p_queue_name
+            using errcode = '40001',
+                  hint = 'Retry spawn_task with the same idempotency key.';
+end if;
+
+        if v_existing_run_id is null then
+          raise exception 'Idempotency key "%" in queue "%" resolved to task "%" without a run', v_idempotency_key, p_queue_name, v_existing_task_id;
+end if;
+
+return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+return;
+end if;
+else
+      -- Unpartitioned queues keep the original unique(idempotency_key)
+      -- behavior directly on t_<queue>.
+      execute format(
+        'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
+         on conflict (idempotency_key) do nothing',
+        't_' || p_queue_name
+      )
+      using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+
+get diagnostics v_row_count = row_count;
+
+if v_row_count = 0 then
+        execute format(
+          'select task_id, last_attempt_run, attempts
+             from absurd.%I
+            where idempotency_key = $1',
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+return;
+end if;
+
+      v_task_inserted := true;
+end if;
+end if;
+
+  if not v_task_inserted then
+    execute format(
+      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)',
+      't_' || p_queue_name
+    )
+    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+end if;
+
+execute format(
+  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+   values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+  'r_' || p_queue_name
+        )
+  using v_run_id, v_task_id, v_attempt, v_now;
+
+return query select v_task_id, v_run_id, v_attempt, true;
+end;
+$$;
+
+create or replace function absurd.complete_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_state jsonb default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_task_id uuid;
+  v_state text;
+  v_now timestamptz := absurd.current_time();
+begin
+execute format(
+  'select task_id, state
+     from absurd.%I
+    where run_id = $1
+    for update',
+  'r_' || p_queue_name
+        )
+  into v_task_id, v_state
+  using p_run_id;
+
+if v_task_id is null then
+    raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_state <> 'running' then
+    if v_state = 'cancelled' then
+      raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+end if;
+    if v_state = 'failed' then
+      raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+end if;
+    raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = ''completed'',
+          completed_at = $2,
+          result = $3
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, v_now, p_state;
+
+execute format(
+  'update absurd.%I
+      set state = ''completed'',
+          completed_payload = $2,
+          last_attempt_run = $3
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using v_task_id, p_state, p_run_id;
+
+execute format(
+  'delete from absurd.%I where run_id = $1',
+  'w_' || p_queue_name
+        ) using p_run_id;
+end;
+$$;
+
+create or replace function absurd.fail_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_reason jsonb,
+  p_retry_at timestamptz default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_task_id uuid;
+  v_attempt integer;
+  v_run_state text;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_now timestamptz := absurd.current_time();
+  v_next_attempt integer;
+  v_delay_seconds double precision := 0;
+  v_next_available timestamptz;
+  v_retry_kind text;
+  v_base double precision;
+  v_factor double precision;
+  v_max_seconds double precision;
+  v_first_started timestamptz;
+  v_cancellation jsonb;
+  v_max_duration bigint;
+  v_task_cancel boolean := false;
+  v_new_run_id uuid;
+  v_task_state_after text;
+  v_recorded_attempt integer;
+  v_last_attempt_run uuid := p_run_id;
+  v_cancelled_at timestamptz := null;
+begin
+execute format(
+  'select r.task_id, r.attempt, r.state
+     from absurd.%I r
+    where r.run_id = $1
+    for update',
+  'r_' || p_queue_name
+        )
+  into v_task_id, v_attempt, v_run_state
+  using p_run_id;
+
+if v_task_id is null then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+end if;
+
+  if v_run_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+end if;
+
+  if v_run_state = 'failed' then
+    raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+end if;
+
+  if v_run_state not in ('running', 'sleeping') then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+end if;
+
+execute format(
+  'select retry_strategy, max_attempts, first_started_at, cancellation
+     from absurd.%I
+    where task_id = $1
+    for update',
+  't_' || p_queue_name
+        )
+  into v_retry_strategy, v_max_attempts, v_first_started, v_cancellation
+  using v_task_id;
+
+execute format(
+  'update absurd.%I
+      set state = ''failed'',
+          wake_event = null,
+          failed_at = $2,
+          failure_reason = $3
+    where run_id = $1',
+  'r_' || p_queue_name
+        ) using p_run_id, v_now, p_reason;
+
+v_next_attempt := v_attempt + 1;
+  v_task_state_after := 'failed';
+  v_recorded_attempt := v_attempt;
+
+  if v_max_attempts is null or v_next_attempt <= v_max_attempts then
+    if p_retry_at is not null then
+      v_next_available := p_retry_at;
+else
+      v_retry_kind := coalesce(v_retry_strategy->>'kind', 'none');
+      if v_retry_kind = 'fixed' then
+        v_base := coalesce((v_retry_strategy->>'base_seconds')::double precision, 60);
+        v_delay_seconds := v_base;
+      elsif v_retry_kind = 'exponential' then
+        v_base := coalesce((v_retry_strategy->>'base_seconds')::double precision, 30);
+        v_factor := coalesce((v_retry_strategy->>'factor')::double precision, 2);
+        v_delay_seconds := v_base * power(v_factor, greatest(v_attempt - 1, 0));
+        v_max_seconds := (v_retry_strategy->>'max_seconds')::double precision;
+        if v_max_seconds is not null then
+          v_delay_seconds := least(v_delay_seconds, v_max_seconds);
+end if;
+else
+        v_delay_seconds := 0;
+end if;
+      v_next_available := v_now + (v_delay_seconds * interval '1 second');
+end if;
+
+    if v_next_available < v_now then
+      v_next_available := v_now;
+end if;
+
+    if v_cancellation is not null then
+      v_max_duration := (v_cancellation->>'max_duration')::bigint;
+      if v_max_duration is not null and v_first_started is not null then
+        if extract(epoch from (v_next_available - v_first_started)) >= v_max_duration then
+          v_task_cancel := true;
+end if;
+end if;
+end if;
+
+    if not v_task_cancel then
+      v_task_state_after := case when v_next_available > v_now then 'sleeping' else 'pending' end;
+      v_new_run_id := absurd.portable_uuidv7();
+      v_recorded_attempt := v_next_attempt;
+      v_last_attempt_run := v_new_run_id;
+execute format(
+  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+   values ($1, $2, $3, $4, $5, null, null, null, null)',
+  'r_' || p_queue_name
+        )
+  using v_new_run_id, v_task_id, v_next_attempt, v_task_state_after, v_next_available;
+end if;
+end if;
+
+  if v_task_cancel then
+    v_task_state_after := 'cancelled';
+    v_cancelled_at := v_now;
+    v_recorded_attempt := greatest(v_recorded_attempt, v_attempt);
+    v_last_attempt_run := p_run_id;
+end if;
+
+execute format(
+  'update absurd.%I
+      set state = $2,
+          attempts = greatest(attempts, $3),
+          last_attempt_run = $4,
+          cancelled_at = coalesce(cancelled_at, $5)
+    where task_id = $1',
+  't_' || p_queue_name
+        ) using v_task_id, v_task_state_after, v_recorded_attempt, v_last_attempt_run, v_cancelled_at;
+
+execute format(
+  'delete from absurd.%I where run_id = $1',
+  'w_' || p_queue_name
+        ) using p_run_id;
+end;
+$$;
+
+create or replace function absurd.cleanup_all_queues (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    tasks_deleted integer,
+    events_deleted integer
+  )
+  language plpgsql
+as $$
+declare
+v_queue record;
+  v_cleanup_ttl_seconds integer;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+end if;
+end if;
+
+for v_queue in
+select
+  q.queue_name,
+  q.cleanup_ttl,
+  q.cleanup_limit
+from absurd.queues q
+where p_queue_name is null or q.queue_name = p_queue_name
+order by q.queue_name
+  loop
+    v_cleanup_ttl_seconds := greatest(
+      floor(extract(epoch from v_queue.cleanup_ttl))::integer,
+      0
+    );
+
+queue_name := v_queue.queue_name;
+    tasks_deleted := absurd.cleanup_tasks(
+      v_queue.queue_name,
+      v_cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+    events_deleted := absurd.cleanup_events(
+      v_queue.queue_name,
+      v_cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+return next;
+end loop;
+end;
+$$;
+
+create or replace function absurd.cleanup_tasks (
+  p_queue_name text,
+  p_ttl_seconds integer,
+  p_limit integer default 1000
+)
+  returns integer
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_cutoff timestamptz;
+  v_deleted_count integer;
+  v_storage_mode text := 'unpartitioned';
+begin
+  if p_ttl_seconds is null or p_ttl_seconds < 0 then
+    raise exception 'TTL must be a non-negative number of seconds';
+end if;
+
+  v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
+
+select storage_mode into v_storage_mode
+from absurd.queues
+where queue_name = p_queue_name;
+
+v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+
+  if v_storage_mode = 'partitioned' then
+    -- Delete in order: wait registrations, checkpoints, runs, idempotency keys,
+    -- then tasks.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_idempotency as (
+          delete from absurd.%5$I i
+           where i.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name,
+      'i_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+else
+    -- Unpartitioned queues keep idempotency key ownership on the task row,
+    -- so no side-table cleanup is needed.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+end if;
+
+return v_deleted_count;
+end;
+$$;
+
+create or replace function absurd.uuidv7_timestamp (p_id uuid)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+  with bytes as (
+    select uuid_send(p_id) as b
+  ),
+  decoded as (
+    select
+      (get_byte(b, 6) >> 4) as version,
+      ((get_byte(b, 0)::bigint << 40) |
+       (get_byte(b, 1)::bigint << 32) |
+       (get_byte(b, 2)::bigint << 24) |
+       (get_byte(b, 3)::bigint << 16) |
+       (get_byte(b, 4)::bigint << 8)  |
+        get_byte(b, 5)::bigint) as ts_ms
+    from bytes
+  )
+select case
+         when version = 7 then 'epoch'::timestamptz + (ts_ms * interval '1 millisecond')
+         else null
+         end
+from decoded;
+$$;
+
+create or replace function absurd.uuidv7_floor (p_ts timestamptz)
+  returns uuid
+  language plpgsql
+  immutable
+  strict
+as $$
+declare
+ts_ms bigint := floor(extract(epoch from p_ts) * 1000)::bigint;
+  b bytea;
+  i int;
+begin
+  if ts_ms < 0 or ts_ms > 281474976710655 then
+    raise exception 'Timestamp "%" is outside UUIDv7 supported range', p_ts;
+end if;
+
+  b := repeat(E'\\000', 16)::bytea;
+for i in 0..5 loop
+    b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
+end loop;
+
+  -- Set UUIDv7 version and RFC4122 variant; keep all randomness bits at 0.
+  b := set_byte(b, 6, (7 << 4));
+  b := set_byte(b, 8, 128);
+
+return encode(b, 'hex')::uuid;
+end;
+$$;
+
+create or replace function absurd.week_bucket_utc (p_ts timestamptz)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+select date_trunc('week', p_ts at time zone 'UTC') at time zone 'UTC';
+$$;
+
+create or replace function absurd.partition_week_tag (p_ts timestamptz)
+  returns text
+  language sql
+  immutable
+  strict
+as $$
+  with bucket as (
+    select absurd.week_bucket_utc(p_ts) at time zone 'UTC' as ts
+  )
+select
+  ((extract(isoyear from ts)::int % 10)::text) ||
+    lpad((extract(week from ts)::int)::text, 2, '0')
+from bucket;
+$$;
+
+create or replace function absurd.ensure_partitions (
+  p_queue_name text default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+  v_week_start timestamptz;
+  v_week_end timestamptz;
+  v_partition_tag text;
+  v_uuid_from uuid;
+  v_uuid_to uuid;
+  v_queue record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+end if;
+end if;
+
+for v_queue in
+select
+  queue_name,
+  default_partition,
+  partition_lookahead,
+  partition_lookback
+from absurd.queues
+where storage_mode = 'partitioned'
+  and (p_queue_name is null or queue_name = p_queue_name)
+order by queue_name
+  loop
+    v_window_start := absurd.week_bucket_utc(v_now - v_queue.partition_lookback);
+v_window_end := absurd.week_bucket_utc(v_now + v_queue.partition_lookahead);
+
+    if v_queue.default_partition = 'enabled' then
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        't_' || v_queue.queue_name || '_d',
+        't_' || v_queue.queue_name
+      );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I default',
+  'r_' || v_queue.queue_name || '_d',
+  'r_' || v_queue.queue_name
+        );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I default',
+  'c_' || v_queue.queue_name || '_d',
+  'c_' || v_queue.queue_name
+        );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I default',
+  'w_' || v_queue.queue_name || '_d',
+  'w_' || v_queue.queue_name
+        );
+end if;
+
+    v_week_start := v_window_start;
+    while v_week_start <= v_window_end loop
+      v_week_end := v_week_start + interval '7 days';
+      v_partition_tag := absurd.partition_week_tag(v_week_start);
+      v_uuid_from := absurd.uuidv7_floor(v_week_start);
+      v_uuid_to := absurd.uuidv7_floor(v_week_end);
+
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I
+   for values from (%L::uuid) to (%L::uuid)',
+  't_' || v_queue.queue_name || '_' || v_partition_tag,
+  't_' || v_queue.queue_name,
+  v_uuid_from,
+  v_uuid_to
+        );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I
+   for values from (%L::uuid) to (%L::uuid)',
+  'r_' || v_queue.queue_name || '_' || v_partition_tag,
+  'r_' || v_queue.queue_name,
+  v_uuid_from,
+  v_uuid_to
+        );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I
+   for values from (%L::uuid) to (%L::uuid)',
+  'c_' || v_queue.queue_name || '_' || v_partition_tag,
+  'c_' || v_queue.queue_name,
+  v_uuid_from,
+  v_uuid_to
+        );
+execute format(
+  'create table if not exists absurd.%I partition of absurd.%I
+   for values from (%L::uuid) to (%L::uuid)',
+  'w_' || v_queue.queue_name || '_' || v_partition_tag,
+  'w_' || v_queue.queue_name,
+  v_uuid_from,
+  v_uuid_to
+        );
+
+v_week_start := v_week_end;
+end loop;
+end loop;
+end;
+$$;
+
+create or replace function absurd.list_detach_candidates (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    parent_table text,
+    partition_table text
+  )
+  language plpgsql
+as $$
+declare
+v_now timestamptz := absurd.current_time();
+  v_queue record;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_parent_oid oid;
+  v_part record;
+  v_upper_uuid uuid;
+  v_upper_ts timestamptz;
+  v_has_rows boolean;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+end if;
+end if;
+
+for v_queue in
+select
+  q.queue_name,
+  q.detach_mode,
+  q.detach_min_age
+from absurd.queues q
+where q.storage_mode = 'partitioned'
+  and q.detach_mode = 'empty'
+  and (p_queue_name is null or q.queue_name = p_queue_name)
+order by q.queue_name
+  loop
+    foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+      v_parent_table := v_parent_prefix || '_' || v_queue.queue_name;
+
+select c.oid
+into v_parent_oid
+from pg_class c
+       join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'absurd'
+  and c.relname = v_parent_table;
+
+if v_parent_oid is null then
+        continue;
+end if;
+
+for v_part in
+select
+  child.relname as partition_name,
+  pg_get_expr(child.relpartbound, child.oid) as part_bound
+from pg_inherits inh
+       join pg_class child on child.oid = inh.inhrelid
+where inh.inhparent = v_parent_oid
+  loop
+        if v_part.part_bound = 'DEFAULT' then
+          continue;
+end if;
+
+select
+  (regexp_match(v_part.part_bound, 'TO \(''([^'']+)''(::uuid)?\)'))[1]::uuid
+into v_upper_uuid;
+
+if v_upper_uuid is null then
+          continue;
+end if;
+
+        v_upper_ts := absurd.uuidv7_timestamp(v_upper_uuid);
+
+        if v_upper_ts is null then
+          continue;
+end if;
+
+        if v_upper_ts >= (v_now - v_queue.detach_min_age) then
+          continue;
+end if;
+
+execute format(
+  'select exists (select 1 from absurd.%I limit 1)',
+  v_part.partition_name
+        )
+  into v_has_rows;
+
+if coalesce(v_has_rows, false) then
+          continue;
+end if;
+
+        queue_name := v_queue.queue_name;
+        parent_table := v_parent_table;
+        partition_table := v_part.partition_name;
+return next;
+end loop;
+end loop;
+end loop;
+end;
+$$;
+
+create or replace function absurd.drop_detached_partition (
+  p_partition_table text,
+  p_unschedule_job_name text default null
+)
+  returns boolean
+  language plpgsql
+as $$
+declare
+v_partition_table text := nullif(trim(coalesce(p_partition_table, '')), '');
+  v_partition_oid oid;
+  v_is_attached boolean := false;
+  v_detach_job_name text;
+begin
+  if p_unschedule_job_name like 'absurd_drop_run_%' then
+    v_detach_job_name :=
+      'absurd_detach_run_' || substr(p_unschedule_job_name, length('absurd_drop_run_') + 1);
+end if;
+
+  if v_partition_table is null then
+    raise exception 'partition table must be provided';
+end if;
+
+select c.oid
+into v_partition_oid
+from pg_class c
+       join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'absurd'
+  and c.relname = v_partition_table;
+
+if v_partition_oid is null then
+    if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+      perform cron.unschedule(jobid)
+        from cron.job
+       where jobname in (p_unschedule_job_name, coalesce(v_detach_job_name, ''));
+end if;
+return false;
+end if;
+
+select exists (
+  select 1
+  from pg_inherits
+  where inhrelid = v_partition_oid
+)
+into v_is_attached;
+
+if v_is_attached then
+    return false;
+end if;
+
+  -- Once detached, stop retrying detach runs immediately. Keep drop
+  -- scheduled until the table is actually dropped.
+  if v_detach_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname = v_detach_job_name;
+end if;
+
+execute format('drop table if exists absurd.%I', v_partition_table);
+
+if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname = p_unschedule_job_name;
+end if;
+
+return true;
+end;
+$$;
+
+create or replace function absurd.schedule_detach_jobs (
+  p_queue_name text default null
+)
+  returns table (
+    job_name text,
+    job_id bigint,
+    queue_name text,
+    partition_table text,
+    job_kind text
+  )
+  language plpgsql
+as $$
+declare
+v_scope text;
+  v_candidate record;
+  v_parent_key text;
+  v_candidate_key text;
+  v_detach_job_name text;
+  v_drop_job_name text;
+  v_detach_command text;
+  v_drop_command text;
+  v_parent_has_default_partition boolean;
+  v_job_id bigint;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+end if;
+
+  v_scope := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+end;
+
+for v_candidate in
+    with candidates as (
+      select
+        c.*,
+        absurd.uuidv7_timestamp(
+          (regexp_match(
+            pg_get_expr(child.relpartbound, child.oid),
+            'TO \(''([^'']+)''(::uuid)?\)'
+          ))[1]::uuid
+        ) as upper_ts
+      from absurd.list_detach_candidates(p_queue_name) c
+      join pg_class child on child.relname = c.partition_table
+      join pg_namespace n on n.oid = child.relnamespace
+      where n.nspname = 'absurd'
+    ),
+    ranked as (
+      select
+        candidates.*,
+        row_number() over (
+          partition by candidates.parent_table
+          order by candidates.upper_ts asc nulls last, candidates.partition_table asc
+        ) as rn
+      from candidates
+    )
+select
+  ranked.queue_name,
+  ranked.parent_table,
+  ranked.partition_table
+from ranked
+where ranked.rn = 1
+order by ranked.queue_name, ranked.parent_table, ranked.partition_table
+  loop
+    v_parent_key := substr(md5(v_candidate.parent_table), 1, 8);
+
+-- Only one active detach pipeline per parent table.
+if exists (
+      select 1
+      from cron.job
+      where jobname like ('absurd_detach_run_%_' || v_parent_key || '_%')
+         or jobname like ('absurd_drop_run_%_' || v_parent_key || '_%')
+    ) then
+      continue;
+end if;
+
+    v_candidate_key := substr(
+      md5(v_candidate.parent_table || ':' || v_candidate.partition_table),
+      1,
+      12
+    );
+
+    v_detach_job_name := format(
+      'absurd_detach_run_%s_%s_%s',
+      v_scope,
+      v_parent_key,
+      v_candidate_key
+    );
+    v_drop_job_name := format(
+      'absurd_drop_run_%s_%s_%s',
+      v_scope,
+      v_parent_key,
+      v_candidate_key
+    );
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_detach_job_name
+         or jobname like ('absurd_detach_run_%_' || v_candidate_key)
+    ) then
+select exists (
+  select 1
+  from pg_class parent
+         join pg_namespace pn on pn.oid = parent.relnamespace
+         join pg_inherits inh on inh.inhparent = parent.oid
+         join pg_class child on child.oid = inh.inhrelid
+  where pn.nspname = 'absurd'
+    and parent.relname = v_candidate.parent_table
+    and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
+)
+into v_parent_has_default_partition;
+
+v_detach_command := format(
+        'alter table absurd.%I detach partition absurd.%I',
+        v_candidate.parent_table,
+        v_candidate.partition_table
+      );
+
+      if not coalesce(v_parent_has_default_partition, false) then
+        v_detach_command := v_detach_command || ' concurrently';
+end if;
+
+execute 'select cron.schedule($1, $2, $3)'
+  into v_job_id
+  using v_detach_job_name, '* * * * *', v_detach_command;
+
+job_name := v_detach_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'detach';
+return next;
+end if;
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_drop_job_name
+         or jobname like ('absurd_drop_run_%_' || v_candidate_key)
+    ) then
+      v_drop_command := format(
+        'select absurd.drop_detached_partition(%L, %L);',
+        v_candidate.partition_table,
+        v_drop_job_name
+      );
+
+execute 'select cron.schedule($1, $2, $3)'
+  into v_job_id
+  using v_drop_job_name, '* * * * *', v_drop_command;
+
+job_name := v_drop_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'drop';
+return next;
+end if;
+end loop;
+end;
+$$;
+
+create or replace function absurd.enable_cron (
+  p_queue_name text default null,
+  p_partition_schedule text default '5 * * * *',
+  p_cleanup_schedule text default '17 * * * *',
+  p_detach_schedule text default '29 * * * *'
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+v_queue_exists boolean := false;
+  v_queue_literal text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_partition_command text;
+  v_cleanup_command text;
+  v_detach_plan_command text;
+  v_partitions_job_id bigint;
+  v_cleanup_job_id bigint;
+  v_detach_plan_job_id bigint;
+  v_existing_job_id bigint;
+  v_job_suffix text;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+select exists (
+  select 1
+  from absurd.queues
+  where queue_name = p_queue_name
+)
+into v_queue_exists;
+
+if not v_queue_exists then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+end if;
+end if;
+
+  if p_partition_schedule is null or length(trim(p_partition_schedule)) = 0 then
+    raise exception 'Partition schedule must be provided';
+end if;
+
+  if p_cleanup_schedule is null or length(trim(p_cleanup_schedule)) = 0 then
+    raise exception 'Cleanup schedule must be provided';
+end if;
+
+  if p_detach_schedule is null or length(trim(p_detach_schedule)) = 0 then
+    raise exception 'Detach schedule must be provided';
+end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+end if;
+
+  v_queue_literal := case
+    when p_queue_name is null then 'null::text'
+    else quote_literal(p_queue_name)
+end;
+
+  v_partition_command := format(
+    'select absurd.ensure_partitions(%s);',
+    v_queue_literal
+  );
+
+  v_cleanup_command := format(
+    'select * from absurd.cleanup_all_queues(%s);',
+    v_queue_literal
+  );
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+
+  v_detach_plan_command := format(
+    'select * from absurd.schedule_detach_jobs(%s);',
+    v_queue_literal
+  );
+
+for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_partition_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+end loop;
+
+for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_cleanup_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+end loop;
+
+for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_detach_plan_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+end loop;
+
+execute 'select cron.schedule($1, $2, $3)'
+  into v_partitions_job_id
+  using v_partition_job_name, p_partition_schedule, v_partition_command;
+
+execute 'select cron.schedule($1, $2, $3)'
+  into v_cleanup_job_id
+  using v_cleanup_job_name, p_cleanup_schedule, v_cleanup_command;
+
+execute 'select cron.schedule($1, $2, $3)'
+  into v_detach_plan_job_id
+  using v_detach_plan_job_name, p_detach_schedule, v_detach_plan_command;
+
+job_name := v_partition_job_name;
+  job_id := v_partitions_job_id;
+return next;
+
+job_name := v_cleanup_job_name;
+  job_id := v_cleanup_job_id;
+return next;
+
+job_name := v_detach_plan_job_name;
+  job_id := v_detach_plan_job_id;
+return next;
+end;
+$$;
+
+create or replace function absurd.disable_cron (
+  p_queue_name text default null
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+v_job_suffix text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_detach_run_pattern text;
+  v_drop_run_pattern text;
+  v_existing_job record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+end if;
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+  v_detach_run_pattern := 'absurd_detach_run_' || v_job_suffix || '_%';
+  v_drop_run_pattern := 'absurd_drop_run_' || v_job_suffix || '_%';
+
+for v_existing_job in
+    execute 'select jobid, jobname
+               from cron.job
+              where jobname = $1
+                 or jobname = $2
+                 or jobname = $3
+                 or jobname like $4
+                 or jobname like $5
+              order by jobname, jobid'
+    using v_partition_job_name,
+          v_cleanup_job_name,
+          v_detach_plan_job_name,
+          v_detach_run_pattern,
+          v_drop_run_pattern
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job.jobid;
+
+    job_name := v_existing_job.jobname;
+    job_id := v_existing_job.jobid;
+return next;
+end loop;
+end;
+$$;

--- a/support/absurd/src/jvmMain/kotlin/dev/wasmo/absurd/RealAbsurd.kt
+++ b/support/absurd/src/jvmMain/kotlin/dev/wasmo/absurd/RealAbsurd.kt
@@ -312,7 +312,7 @@ internal class RealAbsurd(
         )
       }
     } catch (e: PgException) {
-      if (e.isProbablyDueToCanceledTask) return // Nothing to do.
+      if (e.isDueToCanceledTask) return // Nothing to do.
       throw e
     }
   }
@@ -334,7 +334,7 @@ internal class RealAbsurd(
         )
       }
     } catch (e: PgException) {
-      if (e.isProbablyDueToCanceledTask) return // Nothing to do.
+      if (e.isDueToCanceledTask) return // Nothing to do.
       throw e
     }
   }
@@ -626,12 +626,8 @@ private fun PgException.toTaskStateException(): Throwable? {
   }
 }
 
-/**
- * We say 'probably' here 'cause there isn't an Absurd code for these exceptions.
- * https://github.com/earendil-works/absurd/issues/95
- */
-private val PgException.isProbablyDueToCanceledTask: Boolean
-  get() = sqlState == "P0001"
+private val PgException.isDueToCanceledTask: Boolean
+  get() = sqlState == "AB001"
 
 internal class AwaitEventResult(
   val shouldSuspend: Boolean,

--- a/support/absurd/vendor/absurd/README.md
+++ b/support/absurd/vendor/absurd/README.md
@@ -4,6 +4,6 @@ This directory contains code from the Earendil Works' Absurd project.
 
 https://github.com/earendil-works/absurd
 
-Data here is from 0.3.0.
+Data here is from 0.4.0.
 
-https://github.com/earendil-works/absurd/releases/tag/0.3.0
+https://github.com/earendil-works/absurd/releases/tag/0.4.0

--- a/support/absurd/vendor/absurd/sql/absurd.sql
+++ b/support/absurd/vendor/absurd/sql/absurd.sql
@@ -11,6 +11,7 @@
 -- * `c_` for checkpoints (saved states)
 -- * `e_` for emitted events
 -- * `w_` for wait registrations
+-- * `i_` for idempotency keys (partitioned queues only)
 --
 -- `create_queue`, `drop_queue`, and `list_queues` provide the management
 -- surface for provisioning queues safely.
@@ -41,21 +42,37 @@ create function absurd.current_time ()
   volatile
 as $$
 declare
-v_fake text;
+  v_fake text;
 begin
   v_fake := current_setting('absurd.fake_now', true);
   if v_fake is not null and length(trim(v_fake)) > 0 then
     return v_fake::timestamptz;
-end if;
+  end if;
 
-return clock_timestamp();
+  return clock_timestamp();
 end;
 $$;
 
 create table if not exists absurd.queues (
-                                           queue_name text primary key,
-                                           created_at timestamptz not null default absurd.current_time()
-  );
+  queue_name text primary key,
+  created_at timestamptz not null default absurd.current_time(),
+  storage_mode text not null default 'unpartitioned'
+    check (storage_mode in ('unpartitioned', 'partitioned')),
+  default_partition text not null default 'enabled'
+    check (default_partition in ('enabled', 'disabled')),
+  partition_lookahead interval not null default interval '28 days'
+    check (partition_lookahead >= interval '0 seconds'),
+  partition_lookback interval not null default interval '1 day'
+    check (partition_lookback >= interval '0 seconds'),
+  cleanup_ttl interval not null default interval '30 days'
+    check (cleanup_ttl >= interval '0 seconds'),
+  cleanup_limit integer not null default 1000
+    check (cleanup_limit >= 1),
+  detach_mode text not null default 'none'
+    check (detach_mode in ('none', 'empty')),
+  detach_min_age interval not null default interval '30 days'
+    check (detach_min_age >= interval '0 seconds')
+);
 
 -- Returns the Absurd schema release version baked into this SQL file.
 -- During development this is usually "main" and release automation replaces
@@ -65,7 +82,7 @@ create or replace function absurd.get_schema_version ()
   returns text
   language sql
 as $$
-select 'main'::text;
+  select '0.4.0'::text;
 $$;
 
 -- Queue names are used in generated table/index identifiers.
@@ -77,15 +94,15 @@ create function absurd.validate_queue_name (p_queue_name text)
   language plpgsql
 as $$
 begin
-  if p_queue_name is null or length(trim(p_queue_name)) = 0 then
+  if p_queue_name is null or p_queue_name = '' then
     raise exception 'Queue name must be provided';
-end if;
+  end if;
 
   if octet_length(p_queue_name) > 57 then
     raise exception 'Queue name "%" is too long (max 57 bytes).', p_queue_name;
-end if;
+  end if;
 
-return p_queue_name;
+  return p_queue_name;
 end;
 $$;
 
@@ -93,144 +110,230 @@ create function absurd.ensure_queue_tables (p_queue_name text)
   returns void
   language plpgsql
 as $$
+declare
+  v_storage_mode text := 'unpartitioned';
+  v_t_suffix text;
+  v_r_suffix text;
+  v_c_suffix text;
+  v_w_suffix text;
+  v_t_idempotency_def text;
 begin
   perform absurd.validate_queue_name(p_queue_name);
 
-execute format(
-  'create table if not exists absurd.%I (
-      task_id uuid primary key,
-      task_name text not null,
-      params jsonb not null,
-      headers jsonb,
-      retry_strategy jsonb,
-      max_attempts integer,
-      cancellation jsonb,
-      enqueue_at timestamptz not null default absurd.current_time(),
-      first_started_at timestamptz,
-      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-      attempts integer not null default 0,
-      last_attempt_run uuid,
-      completed_payload jsonb,
-      cancelled_at timestamptz,
-      idempotency_key text unique
-   ) with (fillfactor=70)',
-  't_' || p_queue_name
-        );
+  select storage_mode into v_storage_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
 
-execute format(
-  'create table if not exists absurd.%I (
-      run_id uuid primary key,
-      task_id uuid not null,
-      attempt integer not null,
-      state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-      claimed_by text,
-      claim_expires_at timestamptz,
-      available_at timestamptz not null,
-      wake_event text,
-      event_payload jsonb,
-      started_at timestamptz,
-      completed_at timestamptz,
-      failed_at timestamptz,
-      result jsonb,
-      failure_reason jsonb,
-      created_at timestamptz not null default absurd.current_time()
-   ) with (fillfactor=70)',
-  'r_' || p_queue_name
-        );
+  v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
 
-execute format(
-  'create table if not exists absurd.%I (
-      task_id uuid not null,
-      checkpoint_name text not null,
-      state jsonb,
-      status text not null default ''committed'',
-      owner_run_id uuid,
-      updated_at timestamptz not null default absurd.current_time(),
-      primary key (task_id, checkpoint_name)
-   ) with (fillfactor=70)',
-  'c_' || p_queue_name
-        );
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+  end if;
 
-execute format(
-  'create table if not exists absurd.%I (
-      event_name text primary key,
-      payload jsonb,
-      emitted_at timestamptz not null default absurd.current_time()
-   )',
-  'e_' || p_queue_name
-        );
+  if v_storage_mode = 'partitioned' then
+    v_t_suffix := 'partition by range (task_id)';
+    v_r_suffix := 'partition by range (run_id)';
+    v_c_suffix := 'partition by range (task_id)';
+    v_w_suffix := 'partition by range (run_id)';
+    v_t_idempotency_def := 'idempotency_key text';
+  else
+    v_t_suffix := 'with (fillfactor=70)';
+    v_r_suffix := 'with (fillfactor=70)';
+    v_c_suffix := 'with (fillfactor=70)';
+    v_w_suffix := '';
+    v_t_idempotency_def := 'idempotency_key text unique';
+  end if;
 
-execute format(
-  'create table if not exists absurd.%I (
-      task_id uuid not null,
-      run_id uuid not null,
-      step_name text not null,
-      event_name text not null,
-      timeout_at timestamptz,
-      created_at timestamptz not null default absurd.current_time(),
-      primary key (run_id, step_name)
-   )',
-  'w_' || p_queue_name
-        );
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid primary key,
+        task_name text not null,
+        params jsonb not null,
+        headers jsonb,
+        retry_strategy jsonb,
+        max_attempts integer,
+        cancellation jsonb,
+        enqueue_at timestamptz not null default absurd.current_time(),
+        first_started_at timestamptz,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        attempts integer not null default 0,
+        last_attempt_run uuid,
+        completed_payload jsonb,
+        cancelled_at timestamptz,
+        %s
+     ) %s',
+    't_' || p_queue_name,
+    v_t_idempotency_def,
+    v_t_suffix
+  );
 
-execute format(
-  'create index if not exists %I on absurd.%I (state, available_at)',
-  ('r_' || p_queue_name) || '_sai',
-  'r_' || p_queue_name
-        );
+  execute format(
+    'create table if not exists absurd.%I (
+        run_id uuid primary key,
+        task_id uuid not null,
+        attempt integer not null,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        claimed_by text,
+        claim_expires_at timestamptz,
+        available_at timestamptz not null,
+        wake_event text,
+        event_payload jsonb,
+        started_at timestamptz,
+        completed_at timestamptz,
+        failed_at timestamptz,
+        result jsonb,
+        failure_reason jsonb,
+        created_at timestamptz not null default absurd.current_time()
+     ) %s',
+    'r_' || p_queue_name,
+    v_r_suffix
+  );
 
-execute format(
-  'create index if not exists %I on absurd.%I (task_id)',
-  ('r_' || p_queue_name) || '_ti',
-  'r_' || p_queue_name
-        );
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        checkpoint_name text not null,
+        state jsonb,
+        status text not null default ''committed'',
+        owner_run_id uuid,
+        updated_at timestamptz not null default absurd.current_time(),
+        primary key (task_id, checkpoint_name)
+     ) %s',
+    'c_' || p_queue_name,
+    v_c_suffix
+  );
 
-execute format(
-  'create index if not exists %I on absurd.%I (claim_expires_at)
-    where state = ''running''
-      and claim_expires_at is not null',
-  ('r_' || p_queue_name) || '_cei',
-  'r_' || p_queue_name
-        );
+  execute format(
+    'create table if not exists absurd.%I (
+        event_name text primary key,
+        payload jsonb,
+        emitted_at timestamptz not null default absurd.current_time()
+     )',
+    'e_' || p_queue_name
+  );
 
-execute format(
-  'create index if not exists %I on absurd.%I (event_name)',
-  ('w_' || p_queue_name) || '_eni',
-  'w_' || p_queue_name
-        );
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        run_id uuid not null,
+        step_name text not null,
+        event_name text not null,
+        timeout_at timestamptz,
+        created_at timestamptz not null default absurd.current_time(),
+        primary key (run_id, step_name)
+     ) %s',
+    'w_' || p_queue_name,
+    v_w_suffix
+  );
 
-execute format(
-  'create index if not exists %I on absurd.%I (task_id)',
-  ('w_' || p_queue_name) || '_ti',
-  'w_' || p_queue_name
-        );
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          idempotency_key text primary key,
+          task_id uuid not null
+       )',
+      'i_' || p_queue_name
+    );
+  end if;
 
-execute format(
-  'create index if not exists %I on absurd.%I (emitted_at)',
-  ('e_' || p_queue_name) || '_eai',
-  'e_' || p_queue_name
-        );
+  execute format(
+    'create index if not exists %I on absurd.%I (state, available_at)',
+    ('r_' || p_queue_name) || '_sai',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (task_id)',
+    ('r_' || p_queue_name) || '_ti',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (claim_expires_at)
+      where state = ''running''
+        and claim_expires_at is not null',
+    ('r_' || p_queue_name) || '_cei',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (event_name)',
+    ('w_' || p_queue_name) || '_eni',
+    'w_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (task_id)',
+    ('w_' || p_queue_name) || '_ti',
+    'w_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (emitted_at)',
+    ('e_' || p_queue_name) || '_eai',
+    'e_' || p_queue_name
+  );
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create index if not exists %I on absurd.%I (task_id)',
+      ('i_' || p_queue_name) || '_ti',
+      'i_' || p_queue_name
+    );
+
+    perform absurd.ensure_partitions(p_queue_name);
+  end if;
 end;
 $$;
 
--- Creates the queue with the given name.
+-- Creates the queue with the given name and storage mode.
 --
--- If the table already exists, the function returns silently.
-create function absurd.create_queue (p_queue_name text)
+-- Existing queues are idempotent as long as the requested mode matches.
+create function absurd.create_queue (
+  p_queue_name text,
+  p_storage_mode text
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_storage_mode text;
+  v_existing_mode text;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  v_storage_mode := lower(trim(coalesce(p_storage_mode, '')));
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', p_storage_mode;
+  end if;
+
+  insert into absurd.queues (queue_name, storage_mode)
+  values (p_queue_name, v_storage_mode)
+  on conflict (queue_name) do nothing;
+
+  select storage_mode into v_existing_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
+
+  if v_existing_mode is null then
+    raise exception 'Queue "%" was not found after create attempt', p_queue_name;
+  end if;
+
+  if v_existing_mode <> v_storage_mode then
+    raise exception 'Queue "%" already exists with storage mode "%"', p_queue_name, v_existing_mode;
+  end if;
+
+  perform absurd.ensure_queue_tables(p_queue_name);
+end;
+$$;
+
+-- Creates an unpartitioned queue (backward-compatible API).
+create or replace function absurd.create_queue (p_queue_name text)
   returns void
   language plpgsql
 as $$
 begin
-  p_queue_name := absurd.validate_queue_name(p_queue_name);
-
-begin
-insert into absurd.queues (queue_name)
-values (p_queue_name);
-exception when unique_violation then
-    return;
-end;
-
-  perform absurd.ensure_queue_tables(p_queue_name);
+  perform absurd.create_queue(p_queue_name, 'unpartitioned');
 end;
 $$;
 
@@ -242,23 +345,35 @@ create function absurd.drop_queue (p_queue_name text)
   language plpgsql
 as $$
 declare
-v_existing_queue text;
+  v_existing_queue text;
 begin
-select queue_name into v_existing_queue
-from absurd.queues
-where queue_name = p_queue_name;
+  select queue_name into v_existing_queue
+  from absurd.queues
+  where queue_name = p_queue_name;
 
-if v_existing_queue is null then
+  if v_existing_queue is null then
     return;
-end if;
+  end if;
 
-execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);
-execute format('drop table if exists absurd.%I cascade', 'e_' || p_queue_name);
-execute format('drop table if exists absurd.%I cascade', 'c_' || p_queue_name);
-execute format('drop table if exists absurd.%I cascade', 'r_' || p_queue_name);
-execute format('drop table if exists absurd.%I cascade', 't_' || p_queue_name);
+  -- Remove queue-scoped maintenance jobs only when pg_cron is available.
+  if to_regclass('cron.job') is not null and exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    perform absurd.disable_cron(p_queue_name);
+  end if;
 
-delete from absurd.queues where queue_name = p_queue_name;
+  execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);
+  execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);
+  execute format('drop table if exists absurd.%I cascade', 'e_' || p_queue_name);
+  execute format('drop table if exists absurd.%I cascade', 'c_' || p_queue_name);
+  execute format('drop table if exists absurd.%I cascade', 'r_' || p_queue_name);
+  execute format('drop table if exists absurd.%I cascade', 't_' || p_queue_name);
+
+  delete from absurd.queues where queue_name = p_queue_name;
 end;
 $$;
 
@@ -266,8 +381,262 @@ $$;
 create function absurd.list_queues ()
   returns table (queue_name text)
   language sql
-  as $$
-select queue_name from absurd.queues order by queue_name;
+as $$
+  select queue_name from absurd.queues order by queue_name;
+$$;
+
+-- Returns queue maintenance policy metadata.
+create function absurd.get_queue_policy (
+  p_queue_name text
+)
+  returns table (
+    queue_name text,
+    storage_mode text,
+    default_partition text,
+    partition_lookahead interval,
+    partition_lookback interval,
+    cleanup_ttl interval,
+    cleanup_limit integer,
+    detach_mode text,
+    detach_min_age interval
+  )
+  language sql
+as $$
+  select
+    q.queue_name,
+    q.storage_mode,
+    q.default_partition,
+    q.partition_lookahead,
+    q.partition_lookback,
+    q.cleanup_ttl,
+    q.cleanup_limit,
+    q.detach_mode,
+    q.detach_min_age
+  from absurd.queues q
+  where q.queue_name = p_queue_name;
+$$;
+
+-- Updates queue maintenance policy metadata.
+--
+-- p_policy accepts optional keys:
+-- * partition_lookahead (interval text)
+-- * partition_lookback (interval text)
+-- * cleanup_ttl (interval text, >= 0)
+-- * cleanup_limit (integer >= 1)
+-- * detach_mode ('none' | 'empty')
+-- * detach_min_age (interval text)
+-- * default_partition ('enabled' | 'disabled')
+create function absurd.set_queue_policy (
+  p_queue_name text,
+  p_policy jsonb
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_policy jsonb := coalesce(p_policy, '{}'::jsonb);
+  v_unknown_key text;
+  v_exists boolean := false;
+  v_storage_mode text;
+  v_default_partition text;
+  v_previous_default_partition text;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_default_table text;
+  v_default_attached boolean;
+  v_default_has_rows boolean;
+
+  v_partition_lookahead interval;
+  v_partition_lookback interval;
+  v_cleanup_ttl interval;
+  v_cleanup_limit integer;
+  v_detach_mode text;
+  v_detach_min_age interval;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  if jsonb_typeof(v_policy) <> 'object' then
+    raise exception 'Queue policy must be a JSON object';
+  end if;
+
+  select k.key
+    into v_unknown_key
+    from jsonb_object_keys(v_policy) as k(key)
+   where k.key not in (
+      'partition_lookahead',
+      'partition_lookback',
+      'cleanup_ttl',
+      'cleanup_limit',
+      'detach_mode',
+      'detach_min_age',
+      'default_partition'
+   )
+   limit 1;
+
+  if v_unknown_key is not null then
+    raise exception 'Unsupported queue policy key "%"', v_unknown_key;
+  end if;
+
+  select exists (
+    select 1
+    from absurd.queues
+    where queue_name = p_queue_name
+  )
+  into v_exists;
+
+  if not v_exists then
+    raise exception 'Queue "%" does not exist', p_queue_name;
+  end if;
+
+  select
+    storage_mode,
+    default_partition,
+    partition_lookahead,
+    partition_lookback,
+    cleanup_ttl,
+    cleanup_limit,
+    detach_mode,
+    detach_min_age
+  into
+    v_storage_mode,
+    v_default_partition,
+    v_partition_lookahead,
+    v_partition_lookback,
+    v_cleanup_ttl,
+    v_cleanup_limit,
+    v_detach_mode,
+    v_detach_min_age
+  from absurd.queues
+  where queue_name = p_queue_name
+  for update;
+
+  if v_policy ? 'partition_lookahead' then
+    v_partition_lookahead := (v_policy->>'partition_lookahead')::interval;
+  end if;
+
+  if v_policy ? 'partition_lookback' then
+    v_partition_lookback := (v_policy->>'partition_lookback')::interval;
+  end if;
+
+  if v_policy ? 'cleanup_ttl' then
+    v_cleanup_ttl := (v_policy->>'cleanup_ttl')::interval;
+  end if;
+
+  if v_policy ? 'cleanup_limit' then
+    v_cleanup_limit := (v_policy->>'cleanup_limit')::integer;
+  end if;
+
+  if v_policy ? 'detach_mode' then
+    v_detach_mode := lower(trim(coalesce(v_policy->>'detach_mode', '')));
+  end if;
+
+  if v_policy ? 'detach_min_age' then
+    v_detach_min_age := (v_policy->>'detach_min_age')::interval;
+  end if;
+
+  v_previous_default_partition := v_default_partition;
+
+  if v_policy ? 'default_partition' then
+    v_default_partition := lower(trim(coalesce(v_policy->>'default_partition', '')));
+  end if;
+
+  if v_partition_lookahead < interval '0 seconds' then
+    raise exception 'partition_lookahead must be non-negative';
+  end if;
+
+  if v_partition_lookback < interval '0 seconds' then
+    raise exception 'partition_lookback must be non-negative';
+  end if;
+
+  if v_cleanup_ttl < interval '0 seconds' then
+    raise exception 'cleanup_ttl must be non-negative';
+  end if;
+
+  if v_cleanup_limit < 1 then
+    raise exception 'cleanup_limit must be at least 1';
+  end if;
+
+  if v_detach_mode not in ('none', 'empty') then
+    raise exception 'Unsupported detach mode "%"', v_detach_mode;
+  end if;
+
+  if v_detach_min_age < interval '0 seconds' then
+    raise exception 'detach_min_age must be non-negative';
+  end if;
+
+  if v_default_partition not in ('enabled', 'disabled') then
+    raise exception 'Unsupported default_partition mode "%"', v_default_partition;
+  end if;
+
+  if v_storage_mode <> 'partitioned' and v_policy ? 'default_partition' then
+    raise exception 'default_partition policy is only supported for partitioned queues';
+  end if;
+
+  update absurd.queues
+     set default_partition = v_default_partition,
+         partition_lookahead = v_partition_lookahead,
+         partition_lookback = v_partition_lookback,
+         cleanup_ttl = v_cleanup_ttl,
+         cleanup_limit = v_cleanup_limit,
+         detach_mode = v_detach_mode,
+         detach_min_age = v_detach_min_age
+   where queue_name = p_queue_name;
+
+  if v_storage_mode = 'partitioned'
+     and v_previous_default_partition <> v_default_partition then
+    if v_default_partition = 'enabled' then
+      perform absurd.ensure_partitions(p_queue_name);
+    else
+      foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+        v_parent_table := v_parent_prefix || '_' || p_queue_name;
+        v_default_table := v_parent_table || '_d';
+
+        select exists (
+          select 1
+          from pg_inherits inh
+          join pg_class parent on parent.oid = inh.inhparent
+          join pg_class child on child.oid = inh.inhrelid
+          join pg_namespace n on n.oid = parent.relnamespace
+          where n.nspname = 'absurd'
+            and parent.relname = v_parent_table
+            and child.relname = v_default_table
+        )
+        into v_default_attached;
+
+        if not coalesce(v_default_attached, false) then
+          continue;
+        end if;
+
+        -- Block out-of-window writes into the default partition while we
+        -- validate emptiness and detach/drop it.
+        execute format(
+          'lock table absurd.%I in access exclusive mode',
+          v_default_table
+        );
+
+        execute format(
+          'select exists (select 1 from absurd.%I limit 1)',
+          v_default_table
+        )
+        into v_default_has_rows;
+
+        if coalesce(v_default_has_rows, false) then
+          raise exception
+            'Cannot disable default_partition for queue "%": default partition "%" is not empty',
+            p_queue_name,
+            v_default_table;
+        end if;
+
+        execute format(
+          'alter table absurd.%I detach partition absurd.%I',
+          v_parent_table,
+          v_default_table
+        );
+        execute format('drop table if exists absurd.%I', v_default_table);
+      end loop;
+    end if;
+  end if;
+end;
 $$;
 
 -- Returns the current state and terminal payload (if any) for a task.
@@ -280,17 +649,17 @@ create function absurd.get_task_result (
   p_task_id uuid
 )
   returns table (
-                  task_id uuid,
-                  state text,
-                  result jsonb,
-                  failure_reason jsonb
-                )
+    task_id uuid,
+    state text,
+    result jsonb,
+    failure_reason jsonb
+  )
   language plpgsql
 as $$
 begin
   p_queue_name := absurd.validate_queue_name(p_queue_name);
 
-return query execute format(
+  return query execute format(
     'select t.task_id,
             t.state,
             case when t.state = ''completed'' then t.completed_payload else null end as result,
@@ -317,15 +686,15 @@ create function absurd.spawn_task (
   p_options jsonb default '{}'::jsonb
 )
   returns table (
-                  task_id uuid,
-                  run_id uuid,
-                  attempt integer,
-                  created boolean
-                )
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
   language plpgsql
 as $$
 declare
-v_task_id uuid := absurd.portable_uuidv7();
+  v_task_id uuid := absurd.portable_uuidv7();
   v_run_id uuid := absurd.portable_uuidv7();
   v_attempt integer := 1;
   v_headers jsonb;
@@ -334,13 +703,17 @@ v_task_id uuid := absurd.portable_uuidv7();
   v_cancellation jsonb;
   v_idempotency_key text;
   v_existing_task_id uuid;
+  v_existing_run_id uuid;
+  v_existing_attempt integer;
   v_row_count integer;
+  v_storage_mode text := 'unpartitioned';
+  v_task_inserted boolean := false;
   v_now timestamptz := absurd.current_time();
   v_params jsonb := coalesce(p_params, 'null'::jsonb);
 begin
   if p_task_name is null or length(trim(p_task_name)) = 0 then
     raise exception 'task_name must be provided';
-end if;
+  end if;
 
   if p_options is not null then
     v_headers := p_options->'headers';
@@ -349,54 +722,108 @@ end if;
       v_max_attempts := (p_options->>'max_attempts')::int;
       if v_max_attempts is not null and v_max_attempts < 1 then
         raise exception 'max_attempts must be >= 1';
-end if;
-end if;
+      end if;
+    end if;
     v_cancellation := p_options->'cancellation';
     v_idempotency_key := p_options->>'idempotency_key';
-end if;
+  end if;
 
-  -- If idempotency_key is provided, use INSERT ... ON CONFLICT DO NOTHING
   if v_idempotency_key is not null then
+    select storage_mode into v_storage_mode
+    from absurd.queues
+    where queue_name = p_queue_name;
+
+    v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+    if v_storage_mode not in ('unpartitioned', 'partitioned') then
+      raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+    end if;
+
+    if v_storage_mode = 'partitioned' then
+      -- Reserve idempotency key via dedicated side table.
+      execute format(
+        'insert into absurd.%I (idempotency_key, task_id)
+         values ($1, $2)
+         on conflict (idempotency_key) do nothing',
+        'i_' || p_queue_name
+      )
+      using v_idempotency_key, v_task_id;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select i.task_id, t.last_attempt_run, t.attempts
+             from absurd.%I i
+             join absurd.%I t on t.task_id = i.task_id
+            where i.idempotency_key = $1
+              for key share of i',
+          'i_' || p_queue_name,
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        if v_existing_task_id is null then
+          raise exception 'Idempotency key "%" in queue "%" was concurrently cleaned up', v_idempotency_key, p_queue_name
+            using errcode = '40001',
+                  hint = 'Retry spawn_task with the same idempotency key.';
+        end if;
+
+        if v_existing_run_id is null then
+          raise exception 'Idempotency key "%" in queue "%" resolved to task "%" without a run', v_idempotency_key, p_queue_name, v_existing_task_id;
+        end if;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+    else
+      -- Unpartitioned queues keep the original unique(idempotency_key)
+      -- behavior directly on t_<queue>.
+      execute format(
+        'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
+         on conflict (idempotency_key) do nothing',
+        't_' || p_queue_name
+      )
+      using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select task_id, last_attempt_run, attempts
+             from absurd.%I
+            where idempotency_key = $1',
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+
+      v_task_inserted := true;
+    end if;
+  end if;
+
+  if not v_task_inserted then
     execute format(
       'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
-       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
-       on conflict (idempotency_key) do nothing',
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)',
       't_' || p_queue_name
     )
     using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+  end if;
 
-get diagnostics v_row_count = row_count;
-
-if v_row_count = 0 then
-      -- Task already exists, look up existing task info
-      execute format(
-        'select task_id, last_attempt_run, attempts from absurd.%I where idempotency_key = $1',
-        't_' || p_queue_name
-      )
-      into v_existing_task_id, v_run_id, v_attempt
-      using v_idempotency_key;
-
-return query select v_existing_task_id, v_run_id, v_attempt, false;
-return;
-end if;
-else
-    -- No idempotency key, insert normally
-    execute format(
-      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
-       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, null)',
-      't_' || p_queue_name
-    )
-    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id;
-end if;
-
-execute format(
-  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
-   values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+     values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+    'r_' || p_queue_name
+  )
   using v_run_id, v_task_id, v_attempt, v_now;
 
-return query select v_task_id, v_run_id, v_attempt, true;
+  return query select v_task_id, v_run_id, v_attempt, true;
 end;
 $$;
 
@@ -409,21 +836,21 @@ create function absurd.claim_task (
   p_qty integer default 1
 )
   returns table (
-                  run_id uuid,
-                  task_id uuid,
-                  attempt integer,
-                  task_name text,
-                  params jsonb,
-                  retry_strategy jsonb,
-                  max_attempts integer,
-                  headers jsonb,
-                  wake_event text,
-                  event_payload jsonb
-                )
+    run_id uuid,
+    task_id uuid,
+    attempt integer,
+    task_name text,
+    params jsonb,
+    retry_strategy jsonb,
+    max_attempts integer,
+    headers jsonb,
+    wake_event text,
+    event_payload jsonb
+  )
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_claim_timeout integer := greatest(coalesce(p_claim_timeout, 30), 0);
   v_worker_id text := coalesce(nullif(p_worker_id, ''), 'worker');
   v_qty integer := greatest(coalesce(p_qty, 1), 1);
@@ -435,7 +862,7 @@ v_now timestamptz := absurd.current_time();
 begin
   if v_claim_timeout > 0 then
     v_claim_until := v_now + make_interval(secs => v_claim_timeout);
-end if;
+  end if;
 
   -- Keep claim polling work bounded: process at most v_qty expired leases
   -- per claim call.
@@ -445,7 +872,7 @@ end if;
   --
   -- Use cancel_task() so lock order stays consistent (runs first, task second)
   -- with complete_run()/fail_run().
-for v_cancel_candidate in
+  for v_cancel_candidate in
     execute format(
       'select task_id
          from absurd.%I
@@ -469,9 +896,9 @@ for v_cancel_candidate in
   using v_now
   loop
     perform absurd.cancel_task(p_queue_name, v_cancel_candidate.task_id);
-end loop;
+  end loop;
 
-for v_expired_run in
+  for v_expired_run in
     execute format(
       'select run_id,
               claimed_by,
@@ -500,7 +927,7 @@ for v_expired_run in
       )),
       null
     );
-end loop;
+  end loop;
 
   v_sql := format(
     'with candidate as (
@@ -562,7 +989,7 @@ end loop;
     'w_' || p_queue_name
   );
 
-return query execute v_sql using v_now, v_qty, v_worker_id, v_claim_until;
+  return query execute v_sql using v_now, v_qty, v_worker_id, v_claim_until;
 end;
 $$;
 
@@ -576,50 +1003,56 @@ create function absurd.complete_run (
   language plpgsql
 as $$
 declare
-v_task_id uuid;
+  v_task_id uuid;
   v_state text;
   v_now timestamptz := absurd.current_time();
 begin
-execute format(
-  'select task_id, state
-     from absurd.%I
-    where run_id = $1
-    for update',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'select task_id, state
+       from absurd.%I
+      where run_id = $1
+      for update',
+    'r_' || p_queue_name
+  )
   into v_task_id, v_state
   using p_run_id;
 
-if v_task_id is null then
+  if v_task_id is null then
     raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
   if v_state <> 'running' then
+    if v_state = 'cancelled' then
+      raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+    end if;
+    if v_state = 'failed' then
+      raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+    end if;
     raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
-execute format(
-  'update absurd.%I
-      set state = ''completed'',
-          completed_at = $2,
-          result = $3
-    where run_id = $1',
-  'r_' || p_queue_name
-        ) using p_run_id, v_now, p_state;
+  execute format(
+    'update absurd.%I
+        set state = ''completed'',
+            completed_at = $2,
+            result = $3
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, v_now, p_state;
 
-execute format(
-  'update absurd.%I
-      set state = ''completed'',
-          completed_payload = $2,
-          last_attempt_run = $3
-    where task_id = $1',
-  't_' || p_queue_name
-        ) using v_task_id, p_state, p_run_id;
+  execute format(
+    'update absurd.%I
+        set state = ''completed'',
+            completed_payload = $2,
+            last_attempt_run = $3
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using v_task_id, p_state, p_run_id;
 
-execute format(
-  'delete from absurd.%I where run_id = $1',
-  'w_' || p_queue_name
-        ) using p_run_id;
+  execute format(
+    'delete from absurd.%I where run_id = $1',
+    'w_' || p_queue_name
+  ) using p_run_id;
 end;
 $$;
 
@@ -632,40 +1065,40 @@ create function absurd.schedule_run (
   language plpgsql
 as $$
 declare
-v_task_id uuid;
+  v_task_id uuid;
 begin
-execute format(
-  'select task_id
-     from absurd.%I
-    where run_id = $1
-      and state = ''running''
-    for update',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'select task_id
+       from absurd.%I
+      where run_id = $1
+        and state = ''running''
+      for update',
+    'r_' || p_queue_name
+  )
   into v_task_id
   using p_run_id;
 
-if v_task_id is null then
+  if v_task_id is null then
     raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
-execute format(
-  'update absurd.%I
-      set state = ''sleeping'',
-          claimed_by = null,
-          claim_expires_at = null,
-          available_at = $2,
-          wake_event = null
-    where run_id = $1',
-  'r_' || p_queue_name
-        ) using p_run_id, p_wake_at;
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping'',
+            claimed_by = null,
+            claim_expires_at = null,
+            available_at = $2,
+            wake_event = null
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, p_wake_at;
 
-execute format(
-  'update absurd.%I
-      set state = ''sleeping''
-    where task_id = $1',
-  't_' || p_queue_name
-        ) using v_task_id;
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping''
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using v_task_id;
 end;
 $$;
 
@@ -679,8 +1112,9 @@ create function absurd.fail_run (
   language plpgsql
 as $$
 declare
-v_task_id uuid;
+  v_task_id uuid;
   v_attempt integer;
+  v_run_state text;
   v_retry_strategy jsonb;
   v_max_attempts integer;
   v_now timestamptz := absurd.current_time();
@@ -701,49 +1135,60 @@ v_task_id uuid;
   v_last_attempt_run uuid := p_run_id;
   v_cancelled_at timestamptz := null;
 begin
-execute format(
-  'select r.task_id, r.attempt
-     from absurd.%I r
-    where r.run_id = $1
-      and r.state in (''running'', ''sleeping'')
-    for update',
-  'r_' || p_queue_name
-        )
-  into v_task_id, v_attempt
+  execute format(
+    'select r.task_id, r.attempt, r.state
+       from absurd.%I r
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name
+  )
+  into v_task_id, v_attempt, v_run_state
   using p_run_id;
 
-if v_task_id is null then
+  if v_task_id is null then
     raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
-execute format(
-  'select retry_strategy, max_attempts, first_started_at, cancellation
-     from absurd.%I
-    where task_id = $1
-    for update',
-  't_' || p_queue_name
-        )
+  if v_run_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+  end if;
+
+  if v_run_state = 'failed' then
+    raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+  end if;
+
+  if v_run_state not in ('running', 'sleeping') then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+  end if;
+
+  execute format(
+    'select retry_strategy, max_attempts, first_started_at, cancellation
+       from absurd.%I
+      where task_id = $1
+      for update',
+    't_' || p_queue_name
+  )
   into v_retry_strategy, v_max_attempts, v_first_started, v_cancellation
   using v_task_id;
 
-execute format(
-  'update absurd.%I
-      set state = ''failed'',
-          wake_event = null,
-          failed_at = $2,
-          failure_reason = $3
-    where run_id = $1',
-  'r_' || p_queue_name
-        ) using p_run_id, v_now, p_reason;
+  execute format(
+    'update absurd.%I
+        set state = ''failed'',
+            wake_event = null,
+            failed_at = $2,
+            failure_reason = $3
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, v_now, p_reason;
 
-v_next_attempt := v_attempt + 1;
+  v_next_attempt := v_attempt + 1;
   v_task_state_after := 'failed';
   v_recorded_attempt := v_attempt;
 
   if v_max_attempts is null or v_next_attempt <= v_max_attempts then
     if p_retry_at is not null then
       v_next_available := p_retry_at;
-else
+    else
       v_retry_kind := coalesce(v_retry_strategy->>'kind', 'none');
       if v_retry_kind = 'fixed' then
         v_base := coalesce((v_retry_strategy->>'base_seconds')::double precision, 60);
@@ -755,61 +1200,61 @@ else
         v_max_seconds := (v_retry_strategy->>'max_seconds')::double precision;
         if v_max_seconds is not null then
           v_delay_seconds := least(v_delay_seconds, v_max_seconds);
-end if;
-else
+        end if;
+      else
         v_delay_seconds := 0;
-end if;
+      end if;
       v_next_available := v_now + (v_delay_seconds * interval '1 second');
-end if;
+    end if;
 
     if v_next_available < v_now then
       v_next_available := v_now;
-end if;
+    end if;
 
     if v_cancellation is not null then
       v_max_duration := (v_cancellation->>'max_duration')::bigint;
       if v_max_duration is not null and v_first_started is not null then
         if extract(epoch from (v_next_available - v_first_started)) >= v_max_duration then
           v_task_cancel := true;
-end if;
-end if;
-end if;
+        end if;
+      end if;
+    end if;
 
     if not v_task_cancel then
       v_task_state_after := case when v_next_available > v_now then 'sleeping' else 'pending' end;
       v_new_run_id := absurd.portable_uuidv7();
       v_recorded_attempt := v_next_attempt;
       v_last_attempt_run := v_new_run_id;
-execute format(
-  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
-   values ($1, $2, $3, $4, $5, null, null, null, null)',
-  'r_' || p_queue_name
-        )
-  using v_new_run_id, v_task_id, v_next_attempt, v_task_state_after, v_next_available;
-end if;
-end if;
+      execute format(
+        'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+         values ($1, $2, $3, $4, $5, null, null, null, null)',
+        'r_' || p_queue_name
+      )
+      using v_new_run_id, v_task_id, v_next_attempt, v_task_state_after, v_next_available;
+    end if;
+  end if;
 
   if v_task_cancel then
     v_task_state_after := 'cancelled';
     v_cancelled_at := v_now;
     v_recorded_attempt := greatest(v_recorded_attempt, v_attempt);
     v_last_attempt_run := p_run_id;
-end if;
+  end if;
 
-execute format(
-  'update absurd.%I
-      set state = $2,
-          attempts = greatest(attempts, $3),
-          last_attempt_run = $4,
-          cancelled_at = coalesce(cancelled_at, $5)
-    where task_id = $1',
-  't_' || p_queue_name
-        ) using v_task_id, v_task_state_after, v_recorded_attempt, v_last_attempt_run, v_cancelled_at;
+  execute format(
+    'update absurd.%I
+        set state = $2,
+            attempts = greatest(attempts, $3),
+            last_attempt_run = $4,
+            cancelled_at = coalesce(cancelled_at, $5)
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using v_task_id, v_task_state_after, v_recorded_attempt, v_last_attempt_run, v_cancelled_at;
 
-execute format(
-  'delete from absurd.%I where run_id = $1',
-  'w_' || p_queue_name
-        ) using p_run_id;
+  execute format(
+    'delete from absurd.%I where run_id = $1',
+    'w_' || p_queue_name
+  ) using p_run_id;
 end;
 $$;
 
@@ -828,15 +1273,15 @@ create function absurd.retry_task (
   p_options jsonb default '{}'::jsonb
 )
   returns table (
-                  task_id uuid,
-                  run_id uuid,
-                  attempt integer,
-                  created boolean
-                )
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_spawn_new boolean := false;
   v_requested_max_attempts integer;
 
@@ -856,46 +1301,46 @@ begin
   if p_options is not null then
     if p_options ? 'spawn_new' then
       v_spawn_new := coalesce((p_options->>'spawn_new')::boolean, false);
-end if;
+    end if;
     if p_options ? 'max_attempts' then
       v_requested_max_attempts := (p_options->>'max_attempts')::int;
       if v_requested_max_attempts is not null and v_requested_max_attempts < 1 then
         raise exception 'max_attempts must be >= 1';
-end if;
-end if;
-end if;
+      end if;
+    end if;
+  end if;
 
-execute format(
-  'select task_name,
-          params,
-          headers,
-          retry_strategy,
-          max_attempts,
-          cancellation,
-          attempts,
-          state
-     from absurd.%I
-    where task_id = $1
-    for update',
-  't_' || p_queue_name
-        )
+  execute format(
+    'select task_name,
+            params,
+            headers,
+            retry_strategy,
+            max_attempts,
+            cancellation,
+            attempts,
+            state
+       from absurd.%I
+      where task_id = $1
+      for update',
+    't_' || p_queue_name
+  )
   into v_task_name,
-    v_params,
-    v_headers,
-    v_retry_strategy,
-    v_task_max_attempts,
-    v_cancellation,
-    v_task_attempts,
-    v_task_state
+       v_params,
+       v_headers,
+       v_retry_strategy,
+       v_task_max_attempts,
+       v_cancellation,
+       v_task_attempts,
+       v_task_state
   using p_task_id;
 
-if v_task_state is null then
+  if v_task_state is null then
     raise exception 'Task "%" not found in queue "%"', p_task_id, p_queue_name;
-end if;
+  end if;
 
   if v_task_state <> 'failed' then
     raise exception 'Task "%" is not currently failed in queue "%"', p_task_id, p_queue_name;
-end if;
+  end if;
 
   if v_spawn_new then
     v_spawn_options := jsonb_strip_nulls(jsonb_build_object(
@@ -905,45 +1350,45 @@ end if;
       'cancellation', v_cancellation
     ));
 
-return query
-select s.task_id, s.run_id, s.attempt, s.created
-from absurd.spawn_task(p_queue_name, v_task_name, v_params, v_spawn_options) s;
-return;
-end if;
+    return query
+      select s.task_id, s.run_id, s.attempt, s.created
+        from absurd.spawn_task(p_queue_name, v_task_name, v_params, v_spawn_options) s;
+    return;
+  end if;
 
   if v_requested_max_attempts is null then
     v_requested_max_attempts := coalesce(v_task_max_attempts, v_task_attempts) + 1;
-end if;
+  end if;
 
   if v_requested_max_attempts <= v_task_attempts then
     raise exception 'max_attempts (%) must be greater than current attempts (%)',
       v_requested_max_attempts,
       v_task_attempts;
-end if;
+  end if;
 
   v_new_run_id := absurd.portable_uuidv7();
   v_new_attempt := v_task_attempts + 1;
 
-execute format(
-  'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
-   values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+     values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+    'r_' || p_queue_name
+  )
   using v_new_run_id, p_task_id, v_new_attempt, v_now;
 
-execute format(
-  'update absurd.%I
-      set state = ''pending'',
-          attempts = greatest(attempts, $2),
-          max_attempts = $3,
-          last_attempt_run = $4,
-          cancelled_at = null
-    where task_id = $1',
-  't_' || p_queue_name
-        )
+  execute format(
+    'update absurd.%I
+        set state = ''pending'',
+            attempts = greatest(attempts, $2),
+            max_attempts = $3,
+            last_attempt_run = $4,
+            cancelled_at = null
+      where task_id = $1',
+    't_' || p_queue_name
+  )
   using p_task_id, v_new_attempt, v_requested_max_attempts, v_new_run_id;
 
-return query select p_task_id, v_new_run_id, v_new_attempt, false;
+  return query select p_task_id, v_new_run_id, v_new_attempt, false;
 end;
 $$;
 
@@ -959,7 +1404,7 @@ create function absurd.set_task_checkpoint_state (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_new_attempt integer;
   v_existing_attempt integer;
   v_existing_owner uuid;
@@ -968,30 +1413,30 @@ v_now timestamptz := absurd.current_time();
 begin
   if p_step_name is null or length(trim(p_step_name)) = 0 then
     raise exception 'step_name must be provided';
-end if;
+  end if;
 
-execute format(
-  'select r.attempt, r.state, t.state
-     from absurd.%I r
-     join absurd.%I t on t.task_id = r.task_id
-    where r.run_id = $1',
-  'r_' || p_queue_name,
-  't_' || p_queue_name
-        )
+  execute format(
+    'select r.attempt, r.state, t.state
+       from absurd.%I r
+       join absurd.%I t on t.task_id = r.task_id
+      where r.run_id = $1',
+    'r_' || p_queue_name,
+    't_' || p_queue_name
+  )
   into v_new_attempt, v_run_state, v_task_state
   using p_owner_run;
 
-if v_new_attempt is null then
+  if v_new_attempt is null then
     raise exception 'Run "%" not found for checkpoint', p_owner_run;
-end if;
+  end if;
 
   if v_task_state = 'cancelled' then
     raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
-end if;
+  end if;
 
   if v_run_state = 'failed' then
     raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_owner_run, p_queue_name);
-end if;
+  end if;
 
   -- Extend the claim if requested
   if p_extend_claim_by is not null and p_extend_claim_by > 0 then
@@ -1004,22 +1449,22 @@ end if;
       'r_' || p_queue_name
     )
     using p_owner_run, v_now, p_extend_claim_by;
-end if;
+  end if;
 
-execute format(
-  'select c.owner_run_id,
-          r.attempt
-     from absurd.%I c
-     left join absurd.%I r on r.run_id = c.owner_run_id
-    where c.task_id = $1
-      and c.checkpoint_name = $2',
-  'c_' || p_queue_name,
-  'r_' || p_queue_name
-        )
+  execute format(
+    'select c.owner_run_id,
+            r.attempt
+       from absurd.%I c
+       left join absurd.%I r on r.run_id = c.owner_run_id
+      where c.task_id = $1
+        and c.checkpoint_name = $2',
+    'c_' || p_queue_name,
+    'r_' || p_queue_name
+  )
   into v_existing_owner, v_existing_attempt
   using p_task_id, p_step_name;
 
-if v_existing_owner is null or v_existing_attempt is null or v_new_attempt >= v_existing_attempt then
+  if v_existing_owner is null or v_existing_attempt is null or v_new_attempt >= v_existing_attempt then
     execute format(
       'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
        values ($1, $2, $3, ''committed'', $4, $5)
@@ -1030,7 +1475,7 @@ if v_existing_owner is null or v_existing_attempt is null or v_new_attempt >= v_
                      updated_at = excluded.updated_at',
       'c_' || p_queue_name
     ) using p_task_id, p_step_name, p_state, p_owner_run, v_now;
-end if;
+  end if;
 end;
 $$;
 
@@ -1043,54 +1488,54 @@ create function absurd.extend_claim (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_task_state text;
   v_run_state text;
   v_claim_expires_at timestamptz;
 begin
   if p_extend_by is null or p_extend_by <= 0 then
     raise exception 'extend_by must be > 0';
-end if;
+  end if;
 
-execute format(
-  'select r.state,
-          r.claim_expires_at,
-          t.state
-     from absurd.%I r
-     join absurd.%I t on t.task_id = r.task_id
-    where r.run_id = $1
-    for update',
-  'r_' || p_queue_name,
-  't_' || p_queue_name
-        )
+  execute format(
+    'select r.state,
+            r.claim_expires_at,
+            t.state
+       from absurd.%I r
+       join absurd.%I t on t.task_id = r.task_id
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name,
+    't_' || p_queue_name
+  )
   into v_run_state, v_claim_expires_at, v_task_state
   using p_run_id;
 
-if v_run_state is null then
+  if v_run_state is null then
     raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
   if v_task_state = 'cancelled' then
     raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
-end if;
+  end if;
 
   if v_run_state <> 'running' then
     if v_run_state = 'failed' then
       raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
-end if;
+    end if;
     raise exception 'Run "%" is not currently running in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
   if v_claim_expires_at is null then
     raise exception 'Run "%" does not have an active claim in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
-execute format(
-  'update absurd.%I
-      set claim_expires_at = $2 + make_interval(secs => $3)
-    where run_id = $1',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'update absurd.%I
+        set claim_expires_at = $2 + make_interval(secs => $3)
+      where run_id = $1',
+    'r_' || p_queue_name
+  )
   using p_run_id, v_now, p_extend_by;
 end;
 $$;
@@ -1104,16 +1549,16 @@ create function absurd.get_task_checkpoint_state (
   p_include_pending boolean default false
 )
   returns table (
-                  checkpoint_name text,
-                  state jsonb,
-                  status text,
-                  owner_run_id uuid,
-                  updated_at timestamptz
-                )
+    checkpoint_name text,
+    state jsonb,
+    status text,
+    owner_run_id uuid,
+    updated_at timestamptz
+  )
   language plpgsql
 as $$
 begin
-return query execute format(
+  return query execute format(
     'select checkpoint_name, state, status, owner_run_id, updated_at
        from absurd.%I
       where task_id = $1
@@ -1132,36 +1577,36 @@ create function absurd.get_task_checkpoint_states (
   p_run_id uuid
 )
   returns table (
-                  checkpoint_name text,
-                  state jsonb,
-                  status text,
-                  owner_run_id uuid,
-                  updated_at timestamptz
-                )
+    checkpoint_name text,
+    state jsonb,
+    status text,
+    owner_run_id uuid,
+    updated_at timestamptz
+  )
   language plpgsql
 as $$
 declare
-v_run_task_id uuid;
+  v_run_task_id uuid;
   v_run_attempt integer;
 begin
-execute format(
-  'select task_id, attempt
-     from absurd.%I
-    where run_id = $1',
-  'r_' || p_queue_name
-        )
+  execute format(
+    'select task_id, attempt
+       from absurd.%I
+      where run_id = $1',
+    'r_' || p_queue_name
+  )
   into v_run_task_id, v_run_attempt
   using p_run_id;
 
-if v_run_task_id is null then
+  if v_run_task_id is null then
     raise exception 'Run "%" not found in queue "%"', p_run_id, p_queue_name;
-end if;
+  end if;
 
   if v_run_task_id <> p_task_id then
     raise exception 'Run "%" does not belong to task "%" in queue "%"', p_run_id, p_task_id, p_queue_name;
-end if;
+  end if;
 
-return query execute format(
+  return query execute format(
     'select c.checkpoint_name,
             c.state,
             c.status,
@@ -1188,13 +1633,13 @@ create function absurd.await_event (
   p_timeout integer default null
 )
   returns table (
-                  should_suspend boolean,
-                  payload jsonb
-                )
+    should_suspend boolean,
+    payload jsonb
+  )
   language plpgsql
 as $$
 declare
-v_run_state text;
+  v_run_state text;
   v_existing_payload jsonb;
   v_event_payload jsonb;
   v_checkpoint_payload jsonb;
@@ -1207,31 +1652,31 @@ v_run_state text;
 begin
   if p_event_name is null or length(trim(p_event_name)) = 0 then
     raise exception 'event_name must be provided';
-end if;
+  end if;
 
   if p_timeout is not null then
     if p_timeout < 0 then
       raise exception 'timeout must be non-negative';
-end if;
+    end if;
     v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
-end if;
+  end if;
 
   v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
 
-execute format(
-  'select state
-     from absurd.%I
-    where task_id = $1
-      and checkpoint_name = $2',
-  'c_' || p_queue_name
-        )
+  execute format(
+    'select state
+       from absurd.%I
+      where task_id = $1
+        and checkpoint_name = $2',
+    'c_' || p_queue_name
+  )
   into v_checkpoint_payload
   using p_task_id, p_step_name;
 
-if v_checkpoint_payload is not null then
+  if v_checkpoint_payload is not null then
     return query select false, v_checkpoint_payload;
-return;
-end if;
+    return;
+  end if;
 
   -- Ensure a row exists for this event so we can take a row-level lock.
   --
@@ -1241,51 +1686,51 @@ end if;
   -- Lock ordering is important to avoid deadlocks: await_event locks the event
   -- row first (FOR SHARE) and then the run row (FOR UPDATE).  emit_event
   -- naturally locks the event row via its UPSERT before touching waits/runs.
-execute format(
-  'insert into absurd.%I (event_name, payload, emitted_at)
-   values ($1, null, ''epoch''::timestamptz)
-   on conflict (event_name) do nothing',
-  'e_' || p_queue_name
-        ) using p_event_name;
+  execute format(
+    'insert into absurd.%I (event_name, payload, emitted_at)
+     values ($1, null, ''epoch''::timestamptz)
+     on conflict (event_name) do nothing',
+    'e_' || p_queue_name
+  ) using p_event_name;
 
-execute format(
-  'select 1
-     from absurd.%I
-    where event_name = $1
-    for share',
-  'e_' || p_queue_name
-        ) using p_event_name;
+  execute format(
+    'select 1
+       from absurd.%I
+      where event_name = $1
+      for share',
+    'e_' || p_queue_name
+  ) using p_event_name;
 
-execute format(
-  'select r.state, r.event_payload, r.wake_event, t.state
-     from absurd.%I r
-     join absurd.%I t on t.task_id = r.task_id
-    where r.run_id = $1
-    for update',
-  'r_' || p_queue_name,
-  't_' || p_queue_name
-        )
+  execute format(
+    'select r.state, r.event_payload, r.wake_event, t.state
+       from absurd.%I r
+       join absurd.%I t on t.task_id = r.task_id
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name,
+    't_' || p_queue_name
+  )
   into v_run_state, v_existing_payload, v_wake_event, v_task_state
   using p_run_id;
 
-if v_run_state is null then
+  if v_run_state is null then
     raise exception 'Run "%" not found while awaiting event', p_run_id;
-end if;
+  end if;
 
   if v_task_state = 'cancelled' then
     raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
-end if;
+  end if;
 
-execute format(
-  'select payload
-     from absurd.%I
-    where event_name = $1',
-  'e_' || p_queue_name
-        )
+  execute format(
+    'select payload
+       from absurd.%I
+      where event_name = $1',
+    'e_' || p_queue_name
+  )
   into v_event_payload
   using p_event_name;
 
-if v_existing_payload is not null then
+  if v_existing_payload is not null then
     execute format(
       'update absurd.%I
           set event_payload = null
@@ -1295,16 +1740,16 @@ if v_existing_payload is not null then
 
     if v_event_payload is not null and v_event_payload = v_existing_payload then
       v_resolved_payload := v_existing_payload;
-end if;
-end if;
+    end if;
+  end if;
 
   if v_run_state <> 'running' then
     raise exception 'Run "%" must be running to await events', p_run_id;
-end if;
+  end if;
 
   if v_resolved_payload is null and v_event_payload is not null then
     v_resolved_payload := v_event_payload;
-end if;
+  end if;
 
   if v_resolved_payload is not null then
     execute format(
@@ -1317,9 +1762,9 @@ end if;
                      updated_at = excluded.updated_at',
       'c_' || p_queue_name
     ) using p_task_id, p_step_name, v_resolved_payload, p_run_id, v_now;
-return query select false, v_resolved_payload;
-return;
-end if;
+    return query select false, v_resolved_payload;
+    return;
+  end if;
 
   -- Detect if we resumed due to timeout: wake_event matches and payload is null
   if v_resolved_payload is null and v_wake_event = p_event_name and v_existing_payload is null then
@@ -1328,41 +1773,41 @@ end if;
       'update absurd.%I set wake_event = null where run_id = $1',
       'r_' || p_queue_name
     ) using p_run_id;
-return query select false, null::jsonb;
-return;
-end if;
+    return query select false, null::jsonb;
+    return;
+  end if;
 
-execute format(
-  'insert into absurd.%I (task_id, run_id, step_name, event_name, timeout_at, created_at)
-   values ($1, $2, $3, $4, $5, $6)
-   on conflict (run_id, step_name)
-   do update set event_name = excluded.event_name,
-                 timeout_at = excluded.timeout_at,
-                 created_at = excluded.created_at',
-  'w_' || p_queue_name
-        ) using p_task_id, p_run_id, p_step_name, p_event_name, v_timeout_at, v_now;
+  execute format(
+    'insert into absurd.%I (task_id, run_id, step_name, event_name, timeout_at, created_at)
+     values ($1, $2, $3, $4, $5, $6)
+     on conflict (run_id, step_name)
+     do update set event_name = excluded.event_name,
+                   timeout_at = excluded.timeout_at,
+                   created_at = excluded.created_at',
+    'w_' || p_queue_name
+  ) using p_task_id, p_run_id, p_step_name, p_event_name, v_timeout_at, v_now;
 
-execute format(
-  'update absurd.%I
-      set state = ''sleeping'',
-          claimed_by = null,
-          claim_expires_at = null,
-          available_at = $3,
-          wake_event = $2,
-          event_payload = null
-    where run_id = $1',
-  'r_' || p_queue_name
-        ) using p_run_id, p_event_name, v_available_at;
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping'',
+            claimed_by = null,
+            claim_expires_at = null,
+            available_at = $3,
+            wake_event = $2,
+            event_payload = null
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, p_event_name, v_available_at;
 
-execute format(
-  'update absurd.%I
-      set state = ''sleeping''
-    where task_id = $1',
-  't_' || p_queue_name
-        ) using p_task_id;
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping''
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using p_task_id;
 
-return query select true, null::jsonb;
-return;
+  return query select true, null::jsonb;
+  return;
 end;
 $$;
 
@@ -1375,88 +1820,88 @@ create function absurd.emit_event (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_payload jsonb := coalesce(p_payload, 'null'::jsonb);
   v_emit_applied integer;
 begin
   if p_event_name is null or length(trim(p_event_name)) = 0 then
     raise exception 'event_name must be provided';
-end if;
+  end if;
 
   -- Events are immutable once emitted: first write wins.
   --
   -- await_event() may pre-create a row with payload=NULL as a "not emitted"
   -- sentinel. We allow exactly one transition NULL -> JSON payload.
-execute format(
-  'insert into absurd.%1$I as e (event_name, payload, emitted_at)
-   values ($1, $2, $3)
-   on conflict (event_name)
-   do update set payload = excluded.payload,
-                 emitted_at = excluded.emitted_at
-    where e.payload is null',
-  'e_' || p_queue_name
-        ) using p_event_name, v_payload, v_now;
+  execute format(
+    'insert into absurd.%1$I as e (event_name, payload, emitted_at)
+     values ($1, $2, $3)
+     on conflict (event_name)
+     do update set payload = excluded.payload,
+                   emitted_at = excluded.emitted_at
+      where e.payload is null',
+    'e_' || p_queue_name
+  ) using p_event_name, v_payload, v_now;
 
-get diagnostics v_emit_applied = row_count;
+  get diagnostics v_emit_applied = row_count;
 
--- Event was already emitted earlier; do not overwrite cached payload or
--- re-run wakeup side effects.
-if v_emit_applied = 0 then
+  -- Event was already emitted earlier; do not overwrite cached payload or
+  -- re-run wakeup side effects.
+  if v_emit_applied = 0 then
     return;
-end if;
+  end if;
 
-execute format(
-  'with expired_waits as (
-      delete from absurd.%1$I w
-       where w.event_name = $1
-         and w.timeout_at is not null
-         and w.timeout_at <= $2
-       returning w.run_id
-   ),
-   affected as (
-      select run_id, task_id, step_name
-        from absurd.%1$I
-       where event_name = $1
-         and (timeout_at is null or timeout_at > $2)
-   ),
-   updated_runs as (
-      update absurd.%2$I r
-         set state = ''pending'',
-             available_at = $2,
-             wake_event = null,
-             event_payload = $3,
-             claimed_by = null,
-             claim_expires_at = null
-       where r.run_id in (select run_id from affected)
-         and r.state = ''sleeping''
-       returning r.run_id, r.task_id
-   ),
-   checkpoint_upd as (
-      insert into absurd.%3$I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
-      select a.task_id, a.step_name, $3, ''committed'', a.run_id, $2
-        from affected a
-        join updated_runs ur on ur.run_id = a.run_id
-      on conflict (task_id, checkpoint_name)
-      do update set state = excluded.state,
-                    status = excluded.status,
-                    owner_run_id = excluded.owner_run_id,
-                    updated_at = excluded.updated_at
-   ),
-   updated_tasks as (
-      update absurd.%4$I t
-         set state = ''pending''
-       where t.task_id in (select task_id from updated_runs)
-       returning task_id
-   )
-   delete from absurd.%5$I w
-    where w.event_name = $1
-      and w.run_id in (select run_id from updated_runs)',
-  'w_' || p_queue_name,
-  'r_' || p_queue_name,
-  'c_' || p_queue_name,
-  't_' || p_queue_name,
-  'w_' || p_queue_name
-        ) using p_event_name, v_now, v_payload;
+  execute format(
+    'with expired_waits as (
+        delete from absurd.%1$I w
+         where w.event_name = $1
+           and w.timeout_at is not null
+           and w.timeout_at <= $2
+         returning w.run_id
+     ),
+     affected as (
+        select run_id, task_id, step_name
+          from absurd.%1$I
+         where event_name = $1
+           and (timeout_at is null or timeout_at > $2)
+     ),
+     updated_runs as (
+        update absurd.%2$I r
+           set state = ''pending'',
+               available_at = $2,
+               wake_event = null,
+               event_payload = $3,
+               claimed_by = null,
+               claim_expires_at = null
+         where r.run_id in (select run_id from affected)
+           and r.state = ''sleeping''
+         returning r.run_id, r.task_id
+     ),
+     checkpoint_upd as (
+        insert into absurd.%3$I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+        select a.task_id, a.step_name, $3, ''committed'', a.run_id, $2
+          from affected a
+          join updated_runs ur on ur.run_id = a.run_id
+        on conflict (task_id, checkpoint_name)
+        do update set state = excluded.state,
+                      status = excluded.status,
+                      owner_run_id = excluded.owner_run_id,
+                      updated_at = excluded.updated_at
+     ),
+     updated_tasks as (
+        update absurd.%4$I t
+           set state = ''pending''
+         where t.task_id in (select task_id from updated_runs)
+         returning task_id
+     )
+     delete from absurd.%5$I w
+      where w.event_name = $1
+        and w.run_id in (select run_id from updated_runs)',
+    'w_' || p_queue_name,
+    'r_' || p_queue_name,
+    'c_' || p_queue_name,
+    't_' || p_queue_name,
+    'w_' || p_queue_name
+  ) using p_event_name, v_now, v_payload;
 end;
 $$;
 
@@ -1471,61 +1916,119 @@ create function absurd.cancel_task (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_task_state text;
 begin
   -- Lock active runs before the task row so cancel_task() uses the same
   -- lock acquisition order as complete_run()/fail_run().
-execute format(
-  'select run_id
-     from absurd.%I
-    where task_id = $1
-      and state not in (''completed'', ''failed'', ''cancelled'')
-    order by run_id
-    for update',
-  'r_' || p_queue_name
-        ) using p_task_id;
+  execute format(
+    'select run_id
+       from absurd.%I
+      where task_id = $1
+        and state not in (''completed'', ''failed'', ''cancelled'')
+      order by run_id
+      for update',
+    'r_' || p_queue_name
+  ) using p_task_id;
 
-execute format(
-  'select state
-     from absurd.%I
-    where task_id = $1
-    for update',
-  't_' || p_queue_name
-        )
+  execute format(
+    'select state
+       from absurd.%I
+      where task_id = $1
+      for update',
+    't_' || p_queue_name
+  )
   into v_task_state
   using p_task_id;
 
-if v_task_state is null then
+  if v_task_state is null then
     raise exception 'Task "%" not found in queue "%"', p_task_id, p_queue_name;
-end if;
+  end if;
 
   if v_task_state in ('completed', 'failed', 'cancelled') then
     return;
-end if;
+  end if;
 
-execute format(
-  'update absurd.%I
-      set state = ''cancelled'',
-          cancelled_at = coalesce(cancelled_at, $2)
-    where task_id = $1',
-  't_' || p_queue_name
-        ) using p_task_id, v_now;
+  execute format(
+    'update absurd.%I
+        set state = ''cancelled'',
+            cancelled_at = coalesce(cancelled_at, $2)
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using p_task_id, v_now;
 
-execute format(
-  'update absurd.%I
-      set state = ''cancelled'',
-          claimed_by = null,
-          claim_expires_at = null
-    where task_id = $1
-      and state not in (''completed'', ''failed'', ''cancelled'')',
-  'r_' || p_queue_name
-        ) using p_task_id;
+  execute format(
+    'update absurd.%I
+        set state = ''cancelled'',
+            claimed_by = null,
+            claim_expires_at = null
+      where task_id = $1
+        and state not in (''completed'', ''failed'', ''cancelled'')',
+    'r_' || p_queue_name
+  ) using p_task_id;
 
-execute format(
-  'delete from absurd.%I where task_id = $1',
-  'w_' || p_queue_name
-        ) using p_task_id;
+  execute format(
+    'delete from absurd.%I where task_id = $1',
+    'w_' || p_queue_name
+  ) using p_task_id;
+end;
+$$;
+
+-- Runs one cleanup batch for all queues (or one specific queue), using
+-- per-queue policy stored in absurd.queues.
+create function absurd.cleanup_all_queues (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    tasks_deleted integer,
+    events_deleted integer
+  )
+  language plpgsql
+as $$
+declare
+  v_queue record;
+  v_cleanup_ttl_seconds integer;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  for v_queue in
+    select
+      q.queue_name,
+      q.cleanup_ttl,
+      q.cleanup_limit
+    from absurd.queues q
+    where p_queue_name is null or q.queue_name = p_queue_name
+    order by q.queue_name
+  loop
+    v_cleanup_ttl_seconds := greatest(
+      floor(extract(epoch from v_queue.cleanup_ttl))::integer,
+      0
+    );
+
+    queue_name := v_queue.queue_name;
+    tasks_deleted := absurd.cleanup_tasks(
+      v_queue.queue_name,
+      v_cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+    events_deleted := absurd.cleanup_events(
+      v_queue.queue_name,
+      v_cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+    return next;
+  end loop;
 end;
 $$;
 
@@ -1543,66 +2046,129 @@ create function absurd.cleanup_tasks (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_cutoff timestamptz;
   v_deleted_count integer;
+  v_storage_mode text := 'unpartitioned';
 begin
   if p_ttl_seconds is null or p_ttl_seconds < 0 then
     raise exception 'TTL must be a non-negative number of seconds';
-end if;
+  end if;
 
   v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
 
-  -- Delete in order: wait registrations, checkpoints, runs, then tasks
-  -- Use a CTE to find eligible tasks and delete their related data
-execute format(
-  'with eligible_tasks as (
-      select t.task_id,
-             case
-               when t.state = ''completed'' then r.completed_at
-               when t.state = ''failed'' then r.failed_at
-               when t.state = ''cancelled'' then t.cancelled_at
-               else null
-             end as terminal_at
-        from absurd.%1$I t
-        left join absurd.%2$I r on r.run_id = t.last_attempt_run
-       where t.state in (''completed'', ''failed'', ''cancelled'')
-   ),
-   to_delete as (
-      select task_id
-        from eligible_tasks
-       where terminal_at is not null
-         and terminal_at < $1
-       order by terminal_at
-       limit $2
-   ),
-   del_waits as (
-      delete from absurd.%3$I w
-       where w.task_id in (select task_id from to_delete)
-   ),
-   del_checkpoints as (
-      delete from absurd.%4$I c
-       where c.task_id in (select task_id from to_delete)
-   ),
-   del_runs as (
-      delete from absurd.%2$I r
-       where r.task_id in (select task_id from to_delete)
-   ),
-   del_tasks as (
-      delete from absurd.%1$I t
-       where t.task_id in (select task_id from to_delete)
-       returning 1
-   )
-   select count(*) from del_tasks',
-  't_' || p_queue_name,
-  'r_' || p_queue_name,
-  'w_' || p_queue_name,
-  'c_' || p_queue_name
-        )
-  into v_deleted_count
-  using v_cutoff, p_limit;
+  select storage_mode into v_storage_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
 
-return v_deleted_count;
+  v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+
+  if v_storage_mode = 'partitioned' then
+    -- Delete in order: wait registrations, checkpoints, runs, idempotency keys,
+    -- then tasks.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_idempotency as (
+          delete from absurd.%5$I i
+           where i.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name,
+      'i_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+  else
+    -- Unpartitioned queues keep idempotency key ownership on the task row,
+    -- so no side-table cleanup is needed.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+  end if;
+
+  return v_deleted_count;
 end;
 $$;
 
@@ -1619,37 +2185,37 @@ create function absurd.cleanup_events (
   language plpgsql
 as $$
 declare
-v_now timestamptz := absurd.current_time();
+  v_now timestamptz := absurd.current_time();
   v_cutoff timestamptz;
   v_deleted_count integer;
 begin
   if p_ttl_seconds is null or p_ttl_seconds < 0 then
     raise exception 'TTL must be a non-negative number of seconds';
-end if;
+  end if;
 
   v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
 
-execute format(
-  'with to_delete as (
-      select event_name
-        from absurd.%I
-       where emitted_at < $1
-       order by emitted_at
-       limit $2
-   ),
-   del_events as (
-      delete from absurd.%I e
-       where e.event_name in (select event_name from to_delete)
-       returning 1
-   )
-   select count(*) from del_events',
-  'e_' || p_queue_name,
-  'e_' || p_queue_name
-        )
+  execute format(
+    'with to_delete as (
+        select event_name
+          from absurd.%I
+         where emitted_at < $1
+         order by emitted_at
+         limit $2
+     ),
+     del_events as (
+        delete from absurd.%I e
+         where e.event_name in (select event_name from to_delete)
+         returning 1
+     )
+     select count(*) from del_events',
+    'e_' || p_queue_name,
+    'e_' || p_queue_name
+  )
   into v_deleted_count
   using v_cutoff, p_limit;
 
-return v_deleted_count;
+  return v_deleted_count;
 end;
 $$;
 
@@ -1660,7 +2226,7 @@ create function absurd.portable_uuidv7 ()
   volatile
 as $$
 declare
-v_server_num integer := current_setting('server_version_num')::int;
+  v_server_num integer := current_setting('server_version_num')::int;
   ts_ms bigint;
   b bytea;
   rnd bytea;
@@ -1668,18 +2234,853 @@ v_server_num integer := current_setting('server_version_num')::int;
 begin
   if v_server_num >= 180000 then
     return uuidv7 ();
-end if;
+  end if;
   ts_ms := floor(extract(epoch from absurd.current_time()) * 1000)::bigint;
   rnd := uuid_send(uuid_generate_v4 ());
   b := repeat(E'\\000', 16)::bytea;
-for i in 0..5 loop
+  for i in 0..5 loop
     b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
-end loop;
-for i in 6..15 loop
+  end loop;
+  for i in 6..15 loop
     b := set_byte(b, i, get_byte(rnd, i));
-end loop;
+  end loop;
   b := set_byte(b, 6, ((get_byte(b, 6) & 15) | (7 << 4)));
   b := set_byte(b, 8, ((get_byte(b, 8) & 63) | 128));
-return encode(b, 'hex')::uuid;
+  return encode(b, 'hex')::uuid;
+end;
+$$;
+
+-- Extracts the embedded timestamp from a UUIDv7 value.
+-- Returns NULL for non-v7 UUIDs.
+create function absurd.uuidv7_timestamp (p_id uuid)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+  with bytes as (
+    select uuid_send(p_id) as b
+  ),
+  decoded as (
+    select
+      (get_byte(b, 6) >> 4) as version,
+      ((get_byte(b, 0)::bigint << 40) |
+       (get_byte(b, 1)::bigint << 32) |
+       (get_byte(b, 2)::bigint << 24) |
+       (get_byte(b, 3)::bigint << 16) |
+       (get_byte(b, 4)::bigint << 8)  |
+        get_byte(b, 5)::bigint) as ts_ms
+    from bytes
+  )
+  select case
+           when version = 7 then 'epoch'::timestamptz + (ts_ms * interval '1 millisecond')
+           else null
+         end
+  from decoded;
+$$;
+
+-- Returns the lowest UUIDv7 value representable for the given timestamp.
+-- This is useful for time-window partition bounds over UUIDv7 keys.
+create function absurd.uuidv7_floor (p_ts timestamptz)
+  returns uuid
+  language plpgsql
+  immutable
+  strict
+as $$
+declare
+  ts_ms bigint := floor(extract(epoch from p_ts) * 1000)::bigint;
+  b bytea;
+  i int;
+begin
+  if ts_ms < 0 or ts_ms > 281474976710655 then
+    raise exception 'Timestamp "%" is outside UUIDv7 supported range', p_ts;
+  end if;
+
+  b := repeat(E'\\000', 16)::bytea;
+  for i in 0..5 loop
+    b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
+  end loop;
+
+  -- Set UUIDv7 version and RFC4122 variant; keep all randomness bits at 0.
+  b := set_byte(b, 6, (7 << 4));
+  b := set_byte(b, 8, 128);
+
+  return encode(b, 'hex')::uuid;
+end;
+$$;
+
+-- Buckets a timestamp to ISO week start (Monday 00:00) in UTC.
+create function absurd.week_bucket_utc (p_ts timestamptz)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+  select date_trunc('week', p_ts at time zone 'UTC') at time zone 'UTC';
+$$;
+
+-- Returns a compact weekly partition tag in YWW format, where:
+-- * Y = last digit of the ISO year in UTC
+-- * WW = zero-padded ISO week number in UTC (01..53)
+--
+-- ISO weeks do not have week 0; days at year boundaries can belong
+-- to week 52/53 of the previous ISO year.
+--
+-- Examples:
+-- * 2024-01-01 UTC -> 401
+-- * 2021-01-01 UTC -> 053 (ISO week 53 of ISO year 2020)
+create function absurd.partition_week_tag (p_ts timestamptz)
+  returns text
+  language sql
+  immutable
+  strict
+as $$
+  with bucket as (
+    select absurd.week_bucket_utc(p_ts) at time zone 'UTC' as ts
+  )
+  select
+    ((extract(isoyear from ts)::int % 10)::text) ||
+    lpad((extract(week from ts)::int)::text, 2, '0')
+  from bucket;
+$$;
+
+-- Ensures weekly UUIDv7 partitions exist for partitioned queues.
+--
+-- Window selection is queue-policy driven:
+-- * start = week_bucket_utc(now() - partition_lookback)
+-- * end   = week_bucket_utc(now() + partition_lookahead)
+create function absurd.ensure_partitions (
+  p_queue_name text default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_now timestamptz := absurd.current_time();
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+  v_week_start timestamptz;
+  v_week_end timestamptz;
+  v_partition_tag text;
+  v_uuid_from uuid;
+  v_uuid_to uuid;
+  v_queue record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  for v_queue in
+    select
+      queue_name,
+      default_partition,
+      partition_lookahead,
+      partition_lookback
+    from absurd.queues
+    where storage_mode = 'partitioned'
+      and (p_queue_name is null or queue_name = p_queue_name)
+    order by queue_name
+  loop
+    v_window_start := absurd.week_bucket_utc(v_now - v_queue.partition_lookback);
+    v_window_end := absurd.week_bucket_utc(v_now + v_queue.partition_lookahead);
+
+    if v_queue.default_partition = 'enabled' then
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        't_' || v_queue.queue_name || '_d',
+        't_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'r_' || v_queue.queue_name || '_d',
+        'r_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'c_' || v_queue.queue_name || '_d',
+        'c_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'w_' || v_queue.queue_name || '_d',
+        'w_' || v_queue.queue_name
+      );
+    end if;
+
+    v_week_start := v_window_start;
+    while v_week_start <= v_window_end loop
+      v_week_end := v_week_start + interval '7 days';
+      v_partition_tag := absurd.partition_week_tag(v_week_start);
+      v_uuid_from := absurd.uuidv7_floor(v_week_start);
+      v_uuid_to := absurd.uuidv7_floor(v_week_end);
+
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        't_' || v_queue.queue_name || '_' || v_partition_tag,
+        't_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'r_' || v_queue.queue_name || '_' || v_partition_tag,
+        'r_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'c_' || v_queue.queue_name || '_' || v_partition_tag,
+        'c_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'w_' || v_queue.queue_name || '_' || v_partition_tag,
+        'w_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+
+      v_week_start := v_week_end;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- Lists eligible partition tables for detach/drop planning.
+--
+-- This does not execute detach directly.
+-- Callers should construct SQL locally from parent/partition names.
+create function absurd.list_detach_candidates (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    parent_table text,
+    partition_table text
+  )
+  language plpgsql
+as $$
+declare
+  v_now timestamptz := absurd.current_time();
+  v_queue record;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_parent_oid oid;
+  v_part record;
+  v_upper_uuid uuid;
+  v_upper_ts timestamptz;
+  v_has_rows boolean;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  for v_queue in
+    select
+      q.queue_name,
+      q.detach_mode,
+      q.detach_min_age
+    from absurd.queues q
+    where q.storage_mode = 'partitioned'
+      and q.detach_mode = 'empty'
+      and (p_queue_name is null or q.queue_name = p_queue_name)
+    order by q.queue_name
+  loop
+    foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+      v_parent_table := v_parent_prefix || '_' || v_queue.queue_name;
+
+      select c.oid
+        into v_parent_oid
+        from pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+       where n.nspname = 'absurd'
+         and c.relname = v_parent_table;
+
+      if v_parent_oid is null then
+        continue;
+      end if;
+
+      for v_part in
+        select
+          child.relname as partition_name,
+          pg_get_expr(child.relpartbound, child.oid) as part_bound
+        from pg_inherits inh
+        join pg_class child on child.oid = inh.inhrelid
+        where inh.inhparent = v_parent_oid
+      loop
+        if v_part.part_bound = 'DEFAULT' then
+          continue;
+        end if;
+
+        select
+          (regexp_match(v_part.part_bound, 'TO \(''([^'']+)''(::uuid)?\)'))[1]::uuid
+          into v_upper_uuid;
+
+        if v_upper_uuid is null then
+          continue;
+        end if;
+
+        v_upper_ts := absurd.uuidv7_timestamp(v_upper_uuid);
+
+        if v_upper_ts is null then
+          continue;
+        end if;
+
+        if v_upper_ts >= (v_now - v_queue.detach_min_age) then
+          continue;
+        end if;
+
+        execute format(
+          'select exists (select 1 from absurd.%I limit 1)',
+          v_part.partition_name
+        )
+        into v_has_rows;
+
+        if coalesce(v_has_rows, false) then
+          continue;
+        end if;
+
+        queue_name := v_queue.queue_name;
+        parent_table := v_parent_table;
+        partition_table := v_part.partition_name;
+        return next;
+      end loop;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- Drops a detached partition table if it is no longer attached.
+--
+-- Returns true when the table was dropped. If p_unschedule_job_name is
+-- provided and pg_cron is available, the matching cron job is unscheduled
+-- once the partition is gone. The paired detach job (if derivable from
+-- p_unschedule_job_name) is unscheduled as soon as the partition is observed
+-- detached so DETACH does not keep retrying.
+create function absurd.drop_detached_partition (
+  p_partition_table text,
+  p_unschedule_job_name text default null
+)
+  returns boolean
+  language plpgsql
+as $$
+declare
+  v_partition_table text := nullif(trim(coalesce(p_partition_table, '')), '');
+  v_partition_oid oid;
+  v_is_attached boolean := false;
+  v_detach_job_name text;
+begin
+  if p_unschedule_job_name like 'absurd_drop_run_%' then
+    v_detach_job_name :=
+      'absurd_detach_run_' || substr(p_unschedule_job_name, length('absurd_drop_run_') + 1);
+  end if;
+
+  if v_partition_table is null then
+    raise exception 'partition table must be provided';
+  end if;
+
+  select c.oid
+    into v_partition_oid
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'absurd'
+     and c.relname = v_partition_table;
+
+  if v_partition_oid is null then
+    if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+      perform cron.unschedule(jobid)
+        from cron.job
+       where jobname in (p_unschedule_job_name, coalesce(v_detach_job_name, ''));
+    end if;
+    return false;
+  end if;
+
+  select exists (
+    select 1
+    from pg_inherits
+    where inhrelid = v_partition_oid
+  )
+  into v_is_attached;
+
+  if v_is_attached then
+    return false;
+  end if;
+
+  -- Once detached, stop retrying detach runs immediately. Keep drop
+  -- scheduled until the table is actually dropped.
+  if v_detach_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname = v_detach_job_name;
+  end if;
+
+  execute format('drop table if exists absurd.%I', v_partition_table);
+
+  if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname = p_unschedule_job_name;
+  end if;
+
+  return true;
+end;
+$$;
+
+-- Schedules per-parent one-at-a-time cron jobs for detach/drop.
+--
+-- For each parent table, only the oldest eligible partition is scheduled and
+-- only when there is no active detach/drop job for that parent.
+--
+-- Detach jobs run the raw DETACH statement. They use CONCURRENTLY when
+-- possible; if a parent still has an attached DEFAULT partition, they fall
+-- back to non-concurrent DETACH (Postgres limitation).
+--
+-- Drop jobs poll via absurd.drop_detached_partition(); once a partition is
+-- detached, that function unschedules the paired detach job immediately and
+-- keeps retrying drop until the table is gone.
+create function absurd.schedule_detach_jobs (
+  p_queue_name text default null
+)
+  returns table (
+    job_name text,
+    job_id bigint,
+    queue_name text,
+    partition_table text,
+    job_kind text
+  )
+  language plpgsql
+as $$
+declare
+  v_scope text;
+  v_candidate record;
+  v_parent_key text;
+  v_candidate_key text;
+  v_detach_job_name text;
+  v_drop_job_name text;
+  v_detach_command text;
+  v_drop_command text;
+  v_parent_has_default_partition boolean;
+  v_job_id bigint;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_scope := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
+
+  for v_candidate in
+    with candidates as (
+      select
+        c.*,
+        absurd.uuidv7_timestamp(
+          (regexp_match(
+            pg_get_expr(child.relpartbound, child.oid),
+            'TO \(''([^'']+)''(::uuid)?\)'
+          ))[1]::uuid
+        ) as upper_ts
+      from absurd.list_detach_candidates(p_queue_name) c
+      join pg_class child on child.relname = c.partition_table
+      join pg_namespace n on n.oid = child.relnamespace
+      where n.nspname = 'absurd'
+    ),
+    ranked as (
+      select
+        candidates.*,
+        row_number() over (
+          partition by candidates.parent_table
+          order by candidates.upper_ts asc nulls last, candidates.partition_table asc
+        ) as rn
+      from candidates
+    )
+    select
+      ranked.queue_name,
+      ranked.parent_table,
+      ranked.partition_table
+    from ranked
+    where ranked.rn = 1
+    order by ranked.queue_name, ranked.parent_table, ranked.partition_table
+  loop
+    v_parent_key := substr(md5(v_candidate.parent_table), 1, 8);
+
+    -- Only one active detach pipeline per parent table.
+    if exists (
+      select 1
+      from cron.job
+      where jobname like ('absurd_detach_run_%_' || v_parent_key || '_%')
+         or jobname like ('absurd_drop_run_%_' || v_parent_key || '_%')
+    ) then
+      continue;
+    end if;
+
+    v_candidate_key := substr(
+      md5(v_candidate.parent_table || ':' || v_candidate.partition_table),
+      1,
+      12
+    );
+
+    v_detach_job_name := format(
+      'absurd_detach_run_%s_%s_%s',
+      v_scope,
+      v_parent_key,
+      v_candidate_key
+    );
+    v_drop_job_name := format(
+      'absurd_drop_run_%s_%s_%s',
+      v_scope,
+      v_parent_key,
+      v_candidate_key
+    );
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_detach_job_name
+         or jobname like ('absurd_detach_run_%_' || v_candidate_key)
+    ) then
+      select exists (
+        select 1
+        from pg_class parent
+        join pg_namespace pn on pn.oid = parent.relnamespace
+        join pg_inherits inh on inh.inhparent = parent.oid
+        join pg_class child on child.oid = inh.inhrelid
+        where pn.nspname = 'absurd'
+          and parent.relname = v_candidate.parent_table
+          and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
+      )
+      into v_parent_has_default_partition;
+
+      v_detach_command := format(
+        'alter table absurd.%I detach partition absurd.%I',
+        v_candidate.parent_table,
+        v_candidate.partition_table
+      );
+
+      if not coalesce(v_parent_has_default_partition, false) then
+        v_detach_command := v_detach_command || ' concurrently';
+      end if;
+
+      execute 'select cron.schedule($1, $2, $3)'
+        into v_job_id
+        using v_detach_job_name, '* * * * *', v_detach_command;
+
+      job_name := v_detach_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'detach';
+      return next;
+    end if;
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_drop_job_name
+         or jobname like ('absurd_drop_run_%_' || v_candidate_key)
+    ) then
+      v_drop_command := format(
+        'select absurd.drop_detached_partition(%L, %L);',
+        v_candidate.partition_table,
+        v_drop_job_name
+      );
+
+      execute 'select cron.schedule($1, $2, $3)'
+        into v_job_id
+        using v_drop_job_name, '* * * * *', v_drop_command;
+
+      job_name := v_drop_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'drop';
+      return next;
+    end if;
+  end loop;
+end;
+$$;
+
+-- Configures pg_cron jobs for partition provisioning, cleanup, and detach planning.
+--
+-- Detach planning schedules per-partition jobs (via absurd.schedule_detach_jobs)
+-- that run raw DETACH statements and follow-up drop checks.
+--
+-- Requires pg_cron to be installed (or compatible cron schema/functions).
+create function absurd.enable_cron (
+  p_queue_name text default null,
+  p_partition_schedule text default '5 * * * *',
+  p_cleanup_schedule text default '17 * * * *',
+  p_detach_schedule text default '29 * * * *'
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_queue_exists boolean := false;
+  v_queue_literal text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_partition_command text;
+  v_cleanup_command text;
+  v_detach_plan_command text;
+  v_partitions_job_id bigint;
+  v_cleanup_job_id bigint;
+  v_detach_plan_job_id bigint;
+  v_existing_job_id bigint;
+  v_job_suffix text;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    select exists (
+      select 1
+      from absurd.queues
+      where queue_name = p_queue_name
+    )
+    into v_queue_exists;
+
+    if not v_queue_exists then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  if p_partition_schedule is null or length(trim(p_partition_schedule)) = 0 then
+    raise exception 'Partition schedule must be provided';
+  end if;
+
+  if p_cleanup_schedule is null or length(trim(p_cleanup_schedule)) = 0 then
+    raise exception 'Cleanup schedule must be provided';
+  end if;
+
+  if p_detach_schedule is null or length(trim(p_detach_schedule)) = 0 then
+    raise exception 'Detach schedule must be provided';
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_queue_literal := case
+    when p_queue_name is null then 'null::text'
+    else quote_literal(p_queue_name)
+  end;
+
+  v_partition_command := format(
+    'select absurd.ensure_partitions(%s);',
+    v_queue_literal
+  );
+
+  v_cleanup_command := format(
+    'select * from absurd.cleanup_all_queues(%s);',
+    v_queue_literal
+  );
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+
+  v_detach_plan_command := format(
+    'select * from absurd.schedule_detach_jobs(%s);',
+    v_queue_literal
+  );
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_partition_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_cleanup_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_detach_plan_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_partitions_job_id
+    using v_partition_job_name, p_partition_schedule, v_partition_command;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_cleanup_job_id
+    using v_cleanup_job_name, p_cleanup_schedule, v_cleanup_command;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_detach_plan_job_id
+    using v_detach_plan_job_name, p_detach_schedule, v_detach_plan_command;
+
+  job_name := v_partition_job_name;
+  job_id := v_partitions_job_id;
+  return next;
+
+  job_name := v_cleanup_job_name;
+  job_id := v_cleanup_job_id;
+  return next;
+
+  job_name := v_detach_plan_job_name;
+  job_id := v_detach_plan_job_id;
+  return next;
+end;
+$$;
+
+-- Removes pg_cron jobs previously installed by absurd.enable_cron.
+--
+-- If p_queue_name is null, this removes the global ('all') maintenance jobs
+-- and global-scope detach/drop run jobs.
+-- If p_queue_name is provided, this removes jobs for that specific queue scope,
+-- including detach/drop run jobs.
+create function absurd.disable_cron (
+  p_queue_name text default null
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_job_suffix text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_detach_run_pattern text;
+  v_drop_run_pattern text;
+  v_existing_job record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+  v_detach_run_pattern := 'absurd_detach_run_' || v_job_suffix || '_%';
+  v_drop_run_pattern := 'absurd_drop_run_' || v_job_suffix || '_%';
+
+  for v_existing_job in
+    execute 'select jobid, jobname
+               from cron.job
+              where jobname = $1
+                 or jobname = $2
+                 or jobname = $3
+                 or jobname like $4
+                 or jobname like $5
+              order by jobname, jobid'
+    using v_partition_job_name,
+          v_cleanup_job_name,
+          v_detach_plan_job_name,
+          v_detach_run_pattern,
+          v_drop_run_pattern
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job.jobid;
+
+    job_name := v_existing_job.jobname;
+    job_id := v_existing_job.jobid;
+    return next;
+  end loop;
 end;
 $$;


### PR DESCRIPTION
# Summary

This PR updates the vendor'd absurd.sql file to 0.4.0 from the [tagged release](https://github.com/earendil-works/absurd/releases/tag/0.4.0) and adds a new migration to handle 0.3.0 to 0.4.0 from [their migrations directory](https://github.com/earendil-works/absurd/blob/main/sql/migrations/0.3.0-0.4.0.sql).

# Action Items
- [ ] Investigate how to apply migrations required for 0.4.0 https://github.com/earendil-works/absurd/blob/main/sql/migrations/0.3.0-0.4.0.sql