### PR TITLE
Add the downloader and HTTP services

### DIFF
--- a/platform/wit/build.gradle.kts
+++ b/platform/wit/build.gradle.kts
@@ -18,11 +18,13 @@ brevity {
     worlds.add("wasmo:platform/wasmo")
     inputWitPackageDirectories.from(
       File(project.projectDir, "src/wit/content-type"),
+      File(project.projectDir, "src/wit/http"),
       File(project.projectDir, "src/wit/jobs"),
       File(project.projectDir, "src/wit/json"),
       File(project.projectDir, "src/wit/object-store"),
       File(project.projectDir, "src/wit/platform"),
       File(project.projectDir, "src/wit/sql"),
+      File(project.projectDir, "src/wit/transfer-service"),
       File(project.projectDir, "src/wit/uuid"),
       File(project.rootDir, "submodules/wasi-p2/preview2/cli"),
       File(project.rootDir, "submodules/wasi-p2/preview2/clocks"),

--- a/platform/wit/src/wit/content-type/types.wit
+++ b/platform/wit/src/wit/content-type/types.wit
@@ -2,6 +2,8 @@ package wasmo:content-type;
 
 @since(version = 0.1.0)
 interface types {
+  /// An [RFC 2045](https://datatracker.ietf.org/doc/rfc2045/) Media Type, appropriate to
+  /// describe the content type of an HTTP request or response body.
   @since(version = 0.1.0)
   type content-type = string;
 }

--- a/platform/wit/src/wit/http/http.wit
+++ b/platform/wit/src/wit/http/http.wit
@@ -1,0 +1,45 @@
+package wasmo:http;
+
+@since(version = 0.1.0)
+interface types {
+  @since(version = 0.1.0)
+  type url = string;
+
+  @since(version = 0.1.0)
+  record http-request {
+    method: string,
+    url: url,
+    headers: list<header>,
+    body: option<list<u8>>,
+  }
+
+  @since(version = 0.1.0)
+  record http-response {
+    code: u32,
+    headers: list<header>,
+    body: list<u8>,
+  }
+
+  @since(version = 0.1.0)
+  record header {
+    name: string,
+    value: string,
+  }
+
+  @since(version = 0.1.0)
+  variant error-code {
+    internal-error(option<string>)
+  }
+}
+
+@since(version = 0.1.0)
+interface http-service {
+  use types.{
+    error-code,
+    http-request,
+    http-response,
+  };
+
+  @since(version = 0.1.0)
+  execute: func(request: http-request) -> result<http-response, error-code>;
+}

--- a/platform/wit/src/wit/platform/wasmo.wit
+++ b/platform/wit/src/wit/platform/wasmo.wit
@@ -3,40 +3,41 @@ package wasmo:platform;
 /// The API contract between Wasmo OS and its applications.
 @since(version = 0.1.0)
 world wasmo {
-  /// a limited environment with runtime configuration.
+  /// A limited environment with runtime configuration.
   import wasi:cli/environment@0.2.0;
 
-  /// a developer-facing console.
+  /// A developer-facing console.
   import wasi:cli/stderr@0.2.0;
   import wasi:cli/stdout@0.2.0;
 
-  /// stdin is present, but empty.
+  /// Stdin is present, but empty.
   import wasi:cli/stdin@0.2.0;
 
-  /// time.
+  /// Time.
   import wasi:clocks/monotonic-clock@0.2.0;
   import wasi:clocks/wall-clock@0.2.0;
 
-  /// randomness.
+  /// Randomness.
   import wasi:random/insecure-seed@0.2.0;
   import wasi:random/insecure@0.2.0;
   import wasi:random/random@0.2.0;
 
-  /// outbound HTTP calls.
-  import wasi:http/outgoing-handler@0.2.0;
+  /// HTTP inbound and outbound.
+  import wasmo:http/http-service;
+  export wasmo:http/http-service;
 
-  /// inbound HTTP calls.
-  export wasi:http/incoming-handler@0.2.0;
-
-  // object store.
+  // Object store.
   import wasmo:object-store/object-store;
 
-  /// job queue.
+  /// Job queue.
   import wasmo:jobs/job-queue-factory;
   export wasmo:jobs/job-handler-factory;
 
   /// SQL database.
   export wasmo:sql/sql-database-factory;
+
+  /// Data transfer.
+  export wasmo:transfer-service/transfer-service;
 
   /// Invoked after an app is first installed, and after each version update.
   export after-install: func(
@@ -44,6 +45,4 @@ world wasmo {
     old-version: s64,
     new-version: s64,
   );
-
-  // TODO: downloader
 }

--- a/platform/wit/src/wit/transfer-service/transfer-service.wit
+++ b/platform/wit/src/wit/transfer-service/transfer-service.wit
@@ -1,0 +1,40 @@
+package wasmo:transfer-service;
+
+@since(version = 0.1.0)
+interface types {
+  use wasmo:http/types.{http-request, http-response};
+  use wasmo:object-store/types.{key};
+
+  @since(version = 0.1.0)
+  record download-request {
+    http-request: http-request,
+    object-store-key: key,
+  }
+
+  @since(version = 0.1.0)
+  record download-response {
+    /// The response body of this response will be empty.
+    http-response: http-response,
+    /// This is absent if the file was not saved.
+    etag: option<string>,
+  }
+
+  @since(version = 0.1.0)
+  variant error-code {
+    internal-error(option<string>)
+  }
+}
+
+@since(version = 0.1.0)
+interface transfer-service {
+  use types.{
+    error-code,
+    download-request,
+    download-response,
+  };
+
+  /// Make an HTTP request and save its response to the object store.
+  /// This will only write to the object store if the HTTP response is successful.
+  @since(version = 0.1.0)
+  download: func(request: download-request) -> result<download-response, error-code>;
+}


### PR DESCRIPTION
I intend to delete our HTTP service later, replacing it with the standard WASI HTTP service. But it's expedient to use our own HTTP abstraction right now, as its simpler (no streaming, fewer error cases).